### PR TITLE
Transfer APIM 3.0.0 changes from lakwarus fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# kubernetes-artifacts-apim
+# kubernetes-artifacts-apim v3.0.0

--- a/dockerfile/activemq/Dockerfile
+++ b/dockerfile/activemq/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.wso2.com/base-c5
+WORKDIR /opt
+ADD apache-activemq-5.14.0-bin.tar.gz  .
+COPY activemq.sh . 
+EXPOSE 61616
+RUN chgrp -R 0 /opt && chmod -R g+rwX /opt
+CMD ["/opt/activemq.sh"]

--- a/dockerfile/activemq/activemq.sh
+++ b/dockerfile/activemq/activemq.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /opt/apache-activemq-5.14.0/bin/
+./activemq console

--- a/dockerfile/api-core/Dockerfile
+++ b/dockerfile/api-core/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker.wso2.com/base-c5
+COPY wso2apim-3.0.0-m4.zip .
+RUN unzip wso2apim-3.0.0-m4.zip -d /opt
+COPY deployment.yaml /opt/wso2apim-3.0.0-m4/conf/
+EXPOSE 9292
+RUN chgrp -R 0 /opt && chmod -R g+rwX /opt
+CMD ["/opt/wso2apim-3.0.0-m4/bin/carbon.sh"]

--- a/dockerfile/api-core/README.md
+++ b/dockerfile/api-core/README.md
@@ -1,0 +1,2 @@
+copy wso2apim-3.0.0.zip to this folder
+

--- a/dockerfile/api-core/deployment.yaml
+++ b/dockerfile/api-core/deployment.yaml
@@ -1,0 +1,60 @@
+################################################################################
+#   Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved
+#
+#   Licensed under the Apache License, Version 2.0 (the \"License\");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an \"AS IS\" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+################################################################################
+
+  # Carbon Configuration Parameters
+wso2.carbon:
+  # value to uniquely identify a server
+  id: carbon-kernel
+  # server name
+  name: WSO2 Carbon Kernel
+  # ports used by this server
+  ports:
+    # port offset
+    offset: 0
+wso2.cabon.apimgt:
+  # DCR Endpoint URL
+  keyManagerConfigs:
+    dcrEndpoint: http://${env:KEY_MANAGER_SERVICE_HOST}:9763/identity/connect/register
+    # Token Endpoint URL 
+    tokenEndpoint: https://${env:KEY_MANAGER_SERVICE_HOST}:9443/oauth2/token
+    # Revoke Endpoint URL
+    revokeEndpoint: https://${env:KEY_MANAGER_SERVICE_HOST}:9443/oauth2/revoke
+    # Introspect Endpoint URL
+    introspectEndpoint: http://${env:KEY_MANAGER_SERVICE_HOST}:9763/oauth2/introspect
+    # User Credentials
+    keyManagerCredentials:
+      # Username
+      username: admin
+      # Password
+      password: admin
+  identityProviderConfigs:
+    # IDP Base URL
+    identityProviderBaseUrl: https://${env:KEY_MANAGER_SERVICE_HOST}:9443
+    # User Credentials
+    identityProviderCredentials:
+      # Username
+      username: admin
+      # Password
+      password: admin
+  analyticsConfigurations:
+    # DAS server URL
+    dasServerURL: http://localhost:9091
+    # User Credentials
+    dasServerCredentials:
+      # Username
+      username: admin
+      # Password
+      password: admin

--- a/dockerfile/api-gateway/Dockerfile
+++ b/dockerfile/api-gateway/Dockerfile
@@ -1,0 +1,9 @@
+FROM docker.wso2.com/base-c5
+WORKDIR /opt
+COPY wso2apim-gateway-3.0.0-m4.zip .
+RUN unzip wso2apim-gateway-3.0.0-m4.zip
+EXPOSE 9090
+WORKDIR /opt/wso2apim-gateway-3.0.0-m4
+COPY gateway.sh .
+RUN chgrp -R 0 /opt && chmod -R g+rwX /opt
+CMD ["./gateway.sh"]

--- a/dockerfile/api-gateway/gateway.sh
+++ b/dockerfile/api-gateway/gateway.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Get MB HOST and PORT from env and update configs  
+if [[ ! -z "${ACTIVEMQ_SERVICE_HOST}" ]];then
+    if [[ ! -z "${ACTIVEMQ_SERVICE_PORT}" ]];then
+	find org/wso2/carbon/apimgt/gateway/ -type f -print0 | xargs -0 sed -i -e "s/localhost\:61616/${ACTIVEMQ_SERVICE_HOST}:${ACTIVEMQ_SERVICE_PORT}/g"
+    else
+        find org/wso2/carbon/apimgt/gateway/ -type f -print0 | xargs -0 sed -i -e "s/localhost\:61616/${ACTIVEMQ_SERVICE_HOST}:61616/g"
+    fi
+fi
+
+bin/ballerina run service org/wso2/carbon/apimgt/gateway

--- a/dockerfile/base/Dockerfile
+++ b/dockerfile/base/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:8u111-jdk-alpine
+RUN apk update && apk add curl bash bash-doc bash-completion zip unzip
+RUN addgroup -S wso2 && adduser -S -g wso2 wso2

--- a/dockerfile/key-manager/Dockerfile
+++ b/dockerfile/key-manager/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.wso2.com/wso2is:5.3.0
+USER root
+EXPOSE 9443 9763 
+RUN chgrp -R 0 /mnt && chmod -R g+rwX /mnt

--- a/dockerfile/key-manager/README.md
+++ b/dockerfile/key-manager/README.md
@@ -1,0 +1,2 @@
+copy wso2apim-3.0.0.zip to this folder
+

--- a/pattern-1/activemq-deployment.yaml
+++ b/pattern-1/activemq-deployment.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: activemq
+  labels:
+    app: activemq
+    tier: prod
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: activemq
+        tier: prod
+    spec:
+      containers:
+      - image: docker.wso2.com/activemq 
+        name: activemq
+        imagePullPolicy: Never
+

--- a/pattern-1/activemq-service.yaml
+++ b/pattern-1/activemq-service.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: activemq
+  labels:
+    app: activemq
+    tier: prod
+spec:
+  type: ClusterIP
+  ports:
+    # ports that this service should serve on
+    -
+      name: 'tcp'
+      protocol: TCP
+      port: 61616
+      targetPort: 61616
+  # label keys and values that must match in order to receive traffic for this service
+  selector:
+    app: activemq
+    tier: prod

--- a/pattern-1/api-core-deployment.yaml
+++ b/pattern-1/api-core-deployment.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: wso2apim-api-core
+  labels:
+    app: wso2apim-api-core
+    tier: prod
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wso2apim-api-core
+        tier: prod
+    spec:
+      containers:
+      - image: docker.wso2.com/wso2apim:v3.0.0-m4
+        name: wso2apim-api-core
+        #imagePullPolicy: Always
+        env:
+        -
+         name: KUBERNETES_MASTER_SKIP_SSL_VERIFICATION
+         value: "true"
+        ports:
+        -
+          containerPort: 9292
+          protocol: "TCP"
+

--- a/pattern-1/api-core-service.yaml
+++ b/pattern-1/api-core-service.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: wso2apim-api-core
+  labels:
+    app: wso2apim-api-core
+    tier: prod
+spec:
+  type: NodePort
+  ports:
+    # ports that this service should serve on
+    -
+      name: 'servlet-https'
+      port: 443
+      targetPort: 9292
+      nodePort: 32009
+  # label keys and values that must match in order to receive traffic for this service
+  selector:
+    app: wso2apim-api-core
+    tier: prod

--- a/pattern-1/api-gateway-deployment.yaml
+++ b/pattern-1/api-gateway-deployment.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: wso2apim-api-gateway
+  labels:
+    app: wso2apim-api-gateway
+    tier: prod
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wso2apim-api-gateway
+        tier: prod
+    spec:
+      containers:
+      - image: docker.wso2.com/wso2apim-gateway:v3.0.0-m4
+        name: wso2apim-api-gateway
+        #imagePullPolicy: Always
+        env:
+        -
+         name: API_CORE_URL
+         value: "https://wso2apim-api-core"
+        ports:
+        -
+          containerPort: 9292
+          protocol: "TCP"
+

--- a/pattern-1/deploy.sh
+++ b/pattern-1/deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+oc create -f activemq-service.yaml
+oc create -f activemq-deployment.yaml
+sleep 5
+oc create -f key-manager-service.yaml
+oc create -f key-manager-deployment.yaml
+sleep 10
+oc create -f api-core-service.yaml
+sleep 5
+oc create -f api-core-deployment.yaml
+oc create -f api-gateway-deployment.yaml

--- a/pattern-1/key-manager-deployment.yaml
+++ b/pattern-1/key-manager-deployment.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: key-manager
+  labels:
+    app: key-manager
+    tier: prod
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: key-manager
+        tier: prod
+    spec:
+      containers:
+      - image: docker.wso2.com/wso2is:5.3.0-openshift 
+        name: kay-manager
+        imagePullPolicy: Never
+

--- a/pattern-1/key-manager-service.yaml
+++ b/pattern-1/key-manager-service.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Service
+metadata:
+  name: key-manager
+  labels:
+    app: key-manager
+    tier: prod
+spec:
+  type: ClusterIP
+  ports:
+    # ports that this service should serve on
+    -
+      name: 'https'
+      protocol: TCP
+      port: 9443
+      targetPort: 9443
+      name: 'http'
+      protocol: TCP
+      port: 9763
+      targetPort: 9763
+  # label keys and values that must match in order to receive traffic for this service
+  selector:
+    app: key-manager
+    tier: prod

--- a/pattern-1/undeploy.sh
+++ b/pattern-1/undeploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+oc delete -f activemq-service.yaml
+oc delete -f activemq-deployment.yaml
+oc delete -f key-manager-service.yaml
+oc delete -f key-manager-deployment.yaml
+oc delete -f api-core-service.yaml
+oc delete -f api-core-deployment.yaml
+oc delete -f api-gateway-deployment.yaml


### PR DESCRIPTION
This PR transfers the APIM 3.0.0. K8S and Dockerfile artifacts from @lakwarus's fork https://github.com/lakwarus/kubernetes-apim to branch `3.0.0`. After this PR is merged, it will be convenient to do changes to the above artifacts as the milestone releases are done. 