### PR TITLE
Apply squash option if docker api version >= v1.25

### DIFF
--- a/base/build.sh
+++ b/base/build.sh
@@ -18,6 +18,8 @@
 
 # builds the base images - apim-base, analytics, rsync, sshd
 
+set -e
+
 this_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 rsync_dir=$(cd "${this_dir}/rsync"; pwd)
 sshd_dir=$(cd "${this_dir}/sshd"; pwd)
@@ -25,8 +27,21 @@ analytics_dir=$(cd "${this_dir}/analytics"; pwd)
 apim_dir=$(cd "${this_dir}/apim"; pwd)
 mysql_dir=$(cd "${this_dir}/mysql"; pwd)
 
-docker build -t wso2/rsync:1.0.0 $rsync_dir --squash
-docker build -t wso2/sshd:1.0.0 $sshd_dir --squash
-docker build -t wso2/wso2am:2.1.0 $apim_dir --squash
-docker build -t wso2/wso2am-analytics:2.1.0 $analytics_dir --squash
-docker build -t docker.wso2.com/apim-rdbms-kubernetes:2.1.0 $mysql_dir --squash
+function docker_build() {
+    tag=$1
+    path=$2
+    docker_api_version=`docker version | grep -m2 "API version" | tail -n1 | cut -d' ' -f5 | bc -l`
+    echo "Building Docker image ${tag}..."
+    if (( $(echo ${docker_api_version} '>=' 1.25 | bc -l) )); then
+        docker build -t ${tag} ${path} --squash
+    else
+        echo "Docker API version is ${docker_api_version}, ignoring --squash option"
+        docker build -t ${tag} ${path}
+    fi
+}
+
+docker_build wso2/rsync:1.0.0 $rsync_dir 
+docker_build wso2/sshd:1.0.0 $sshd_dir 
+docker_build wso2/wso2am:2.1.0 $apim_dir 
+docker_build wso2/wso2am-analytics:2.1.0 $analytics_dir 
+docker_build wso2/apim-rdbms-kubernetes:2.1.0 $mysql_dir 


### PR DESCRIPTION
This pull request updates base/build.sh script to apply squash option only if Docker API version is >= v1.25. Currently, this script fails on Minishift v1.5.0+ae62cf2 with Docker API version v1.24.