### PR TITLE
Add storage classes to deploy NFS with reencrypt routes for Openshift

### DIFF
--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-1-deployment.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-1-deployment.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       hostname: wso2apim-analytics-1
       containers:
-      - image: docker.wso2.com/wso2am-analytics-kubernetes:2.1.0
+      - image: wso2am-analytics-kubernetes:2.2.0
         name: wso2apim-analytics
         imagePullPolicy: IfNotPresent
         resources:
@@ -105,25 +105,25 @@ spec:
           periodSeconds: 20
         volumeMounts:
           - name: apim-analytics-storage-volume
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0/repository/data/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0/repository/data/"
           - name: apim-analytics-1-bin
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/bin/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/bin/"
           - name: apim-analytics-1-conf
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf/"
           - name: apim-analytics-1-spark
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-analytics-spark/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-analytics-spark/"
           - name: apim-analytics-1-axis2
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-axis2/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-axis2/"
           - name: apim-analytics-1-datasources
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-datasources/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-datasources/"
           - name: apim-analytics-1-tomcat
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-tomcat/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-tomcat/"
           - name: apim-analytics-1-conf-analytics
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-analytics/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-analytics/"
       volumes:
         - name: apim-analytics-storage-volume
           persistentVolumeClaim:
-            claimName: apim-analytics-volume-claim-1
+            claimName: apim-analytics-volume-claim
         - name: apim-analytics-1-bin
           configMap:
             name: apim-analytics-1-bin

--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-2-deployment.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-2-deployment.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       hostname: wso2apim-analytics-2
       containers:
-      - image: docker.wso2.com/wso2am-analytics-kubernetes:2.1.0
+      - image: wso2am-analytics-kubernetes:2.2.0
         name: wso2apim-analytics
         imagePullPolicy: IfNotPresent
         resources:
@@ -99,25 +99,25 @@ spec:
           periodSeconds: 20
         volumeMounts:
           - name: apim-analytics2-storage-volume
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0/repository/data/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0/repository/data/"
           - name: apim-analytics-2-bin
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/bin/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/bin/"
           - name: apim-analytics-2-conf
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf/"
           - name: apim-analytics-2-spark
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-analytics-spark/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-analytics-spark/"
           - name: apim-analytics-2-axis2
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-axis2/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-axis2/"
           - name: apim-analytics-2-datasources
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-datasources/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-datasources/"
           - name: apim-analytics-2-tomcat
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-tomcat/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-tomcat/"
           - name: apim-analytics-2-conf-analytics
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-analytics/"
+            mountPath: "/home/wso2user/wso2am-analytics-2.2.0-conf/conf-analytics/"
       volumes:
         - name: apim-analytics2-storage-volume
           persistentVolumeClaim:
-            claimName: apim-analytics-volume-claim-2
+            claimName: apim-analytics-volume-claim
         - name: apim-analytics-2-bin
           configMap:
             name: apim-analytics-2-bin

--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-volume-claim.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-volume-claim.yaml
@@ -15,27 +15,14 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: apim-analytics-volume-claim-1
+  name: apim-analytics-volume-claim
   labels:
     app: apim-analytics
-    pattern: wso2apim-pattern-1
+    pattern: wso2analytics-pattern-1
 spec:
+  storageClassName: nfs
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
-      storage: 1Gi
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: apim-analytics-volume-claim-2
-  labels:
-    app: apim-analytics
-    pattern: wso2apim-pattern-1
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
+      storage: 25Gi

--- a/pattern-1/artifacts/apim/wso2apim-manager-worker-deployment.yaml
+++ b/pattern-1/artifacts/apim/wso2apim-manager-worker-deployment.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       -
-        image: docker.wso2.com/wso2am-kubernetes:2.1.0
+        image: wso2am-kubernetes:2.2.0
         name: wso2apim
         imagePullPolicy: IfNotPresent
         ports:
@@ -62,21 +62,20 @@ spec:
           protocol: "TCP"
 
         volumeMounts:
-        -
-          name: apim-mgt-storage-volume
-          mountPath: "/home/wso2user/wso2am-2.1.0/repository/deployment/server"
+        - name: apim-mgt-storage-volume
+          mountPath: "/home/wso2user/wso2am-2.2.0/repository/deployment/server"
         - name: apim-manager-worker-bin
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/bin/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/bin/"
         - name: apim-manager-worker-conf
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf/"
         - name: apim-manager-worker-identity
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf-identity/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf-identity/"
         - name: apim-manager-worker-axis2
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf-axis2/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf-axis2/"
         - name: apim-manager-worker-datasources
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf-datasources/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf-datasources/"
         - name: apim-manager-worker-tomcat
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf-tomcat/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf-tomcat/"
         livenessProbe:
           tcpSocket:
             port: 9443

--- a/pattern-1/artifacts/apim/wso2apim-mgt-volume-claim.yaml
+++ b/pattern-1/artifacts/apim/wso2apim-mgt-volume-claim.yaml
@@ -17,11 +17,12 @@ kind: PersistentVolumeClaim
 metadata:
   name: apim-mgt-volume-claim
   labels:
-    app: apim-gateway
+    type: NFS
     pattern: wso2apim-pattern-1
 spec:
+  storageClassName: nfs
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
-      storage: 1Gi
+      storage: 25Gi

--- a/pattern-1/artifacts/apim/wso2apim-worker-deployment.yaml
+++ b/pattern-1/artifacts/apim/wso2apim-worker-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         pattern: wso2apim-pattern-1
     spec:
       containers:
-      - image: docker.wso2.com/wso2am-kubernetes:2.1.0
+      - image: wso2am-kubernetes:2.2.0
         name: wso2apim
         imagePullPolicy: IfNotPresent
         ports:
@@ -65,19 +65,19 @@ spec:
 
         volumeMounts:
         - name: apim-mgt-storage-volume
-          mountPath: "/home/wso2user/wso2am-2.1.0/repository/deployment/server"
+          mountPath: "/home/wso2user/wso2am-2.2.0/repository/deployment/server"
         - name: apim-worker-bin
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/bin/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/bin/"
         - name: apim-worker-conf
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf/"
         - name: apim-worker-identity
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf-identity/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf-identity/"
         - name: apim-worker-axis2
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf-axis2/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf-axis2/"
         - name: apim-worker-datasources
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf-datasources/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf-datasources/"
         - name: apim-worker-tomcat
-          mountPath: "/home/wso2user/wso2am-2.1.0-conf/conf-tomcat/"
+          mountPath: "/home/wso2user/wso2am-2.2.0-conf/conf-tomcat/"
         livenessProbe:
           tcpSocket:
             port: 9443

--- a/pattern-1/artifacts/deploy-openshift.sh
+++ b/pattern-1/artifacts/deploy-openshift.sh
@@ -53,10 +53,10 @@ oc create configmap apim-worker-datasources --from-file=../confs/apim-worker/rep
 oc create configmap apim-worker-tomcat --from-file=../confs/apim-worker/repository/conf/tomcat/
 
 # databases
-echo 'deploying databases ...'
-oc create -f rdbms/rdbms-persistent-volume-claim.yaml
-oc create -f rdbms/rdbms-service.yaml
-oc create -f rdbms/rdbms-deployment.yaml
+#echo 'deploying databases ...'
+#oc create -f rdbms/rdbms-persistent-volume-claim.yaml
+#oc create -f rdbms/rdbms-service.yaml
+#oc create -f rdbms/rdbms-deployment.yaml
 
 echo 'deploying services and volume claims ...'
 oc create -f apim-analytics/wso2apim-analytics-service.yaml

--- a/pattern-1/artifacts/routes/wso2apim-analytics-route.yaml
+++ b/pattern-1/artifacts/routes/wso2apim-analytics-route.yaml
@@ -19,11 +19,22 @@ metadata:
   labels:
     pattern: wso2apim-pattern-1
 spec:
-  host: wso2apim-analytics
+  host: analytics.customer.poc.wso2.com
   port:
     targetPort: servlet-https
   to:
     kind: Service
     name: wso2apim-analytics
   tls:
-    termination: passthrough
+    termination: reencrypt
+    key: |-
+      -----BEGIN RSA PRIVATE KEY-----
+      -----END RSA PRIVATE KEY-----
+
+    certificate: |-
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE----- 
+
+    destinationCACertificate: |-
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----

--- a/pattern-1/artifacts/routes/wso2apim-gw-route.yaml
+++ b/pattern-1/artifacts/routes/wso2apim-gw-route.yaml
@@ -19,11 +19,26 @@ metadata:
   labels:
     pattern: wso2apim-pattern-1
 spec:
-  host: wso2apim-gw
+  host: gateway.customer.poc.wso2.com
   port:
     targetPort: pass-through-https
   to:
     kind: Service
     name: wso2apim
   tls:
-    termination: passthrough
+    termination: reencrypt
+    key: |-
+      -----BEGIN RSA PRIVATE KEY-----
+      -----END RSA PRIVATE KEY-----
+
+    certificate: |-
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----
+
+    caCertificate: |-
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE----- 
+
+    destinationCACertificate: |-
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----

--- a/pattern-1/artifacts/routes/wso2apim-route.yaml
+++ b/pattern-1/artifacts/routes/wso2apim-route.yaml
@@ -19,11 +19,26 @@ metadata:
   labels:
     pattern: wso2apim-pattern-1
 spec:
-  host: wso2apim
+  host: wso2apim.customer.poc.wso2.com
   port:
     targetPort: servlet-https
   to:
     kind: Service
     name: wso2apim
   tls:
-    termination: passthrough
+    termination: reencrypt
+    key: |-
+      -----BEGIN RSA PRIVATE KEY-----
+      -----END RSA PRIVATE KEY-----
+
+    certificate: |-
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----
+
+    caCertificate: |-
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE----- 
+
+    destinationCACertificate: |-
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE----- 

--- a/pattern-1/artifacts/volumes/persistent-volumes.yaml
+++ b/pattern-1/artifacts/volumes/persistent-volumes.yaml
@@ -15,72 +15,37 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: local-pv-1
+  name: nfs-pv-1
   labels:
-    type: local
+    type: NFS
     pattern: wso2apim-pattern-1
 spec:
+  storageClassName: nfs
   capacity:
-    storage: 1Gi
+    storage: 25Gi
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   persistentVolumeReclaimPolicy: Recycle
   nfs:
-    # FIXME: use the right IP
-    #Example Path in NFS server: /exports/pattern-1/anlytics2
-    server: <NFS-Server-IP>
-    path: "<NFS location path>"
+    server: <NFS_SERVER_IP>
+    path: /path/to/mount/for/apim
+
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: local-pv-2
+  name: nfs-pv-2
   labels:
-    type: local
-    pattern: wso2apim-pattern-1
+    type: NFS
+    pattern: wso2analytics-pattern-1
 spec:
+  storageClassName: nfs
   capacity:
-    storage: 20Gi
+    storage: 25Gi
   accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Delete
-  hostPath:
-    path: /tmp/data/pattern-1-pv-2
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: local-pv-3
-  labels:
-    type: local
-    pattern: wso2apim-pattern-1
-spec:
-  capacity:
-    storage: 2Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Delete
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Recycle
   nfs:
-  # FIXME: use the right IP
-  #Example Path in NFS server: /exports/pattern-1/anlytics2
-    server: <NFS-Server-IP>
-    path: "<NFS location path>"
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: local-pv-4
-  labels:
-    type: local
-    pattern: wso2apim-pattern-1
-spec:
-  capacity:
-    storage: 2Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Delete
-  nfs:
-  # FIXME: use the right IP
-  #Example Path in NFS server: /exports/pattern-1/apim
-    server: <NFS-Server-IP>
-    path: "<NFS location path>"
+    server: <NFS_SERVER_IP>
+    path: /path/to/mount/for/apim-analytics
+

--- a/pattern-1/artifacts/volumes/storageclass.yaml
+++ b/pattern-1/artifacts/volumes/storageclass.yaml
@@ -1,0 +1,5 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: nfs
+provisioner: kubernetes.io/nfs


### PR DESCRIPTION
## Purpose
> Fixing TLS reencryption termination for openshift routes
> Fixing issues in AWS peristanceVolume creation with NFS server to mount artifact location

## Goals
> Create APIM setup on AWS with openshift by using proper routes configured
> Uses NFS server with a StorageClass that will bound NFS to persiatnceVolume and VolumeClaim for artifact sync

## Approach
> Change tls termination in routes to reencrypt and intorduce to certificates in the routes.
> Create a new Storage class for type NFS and create Volume mounts with persitanceVolumes created using the nfs type storageClass