### PR TITLE
Add required configurations to mount conf/analytics folder

### DIFF
--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-1-deployment.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-1-deployment.yaml
@@ -121,7 +121,7 @@ spec:
           - name: apim-analytics-1-conf-analytics
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-analytics/"
           - name: apim-analytics-1-conf-analytics-volume
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0/repository/conf/analytics"
+            mountPath: "/home/wso2user/wso2am-analytics-2.1.0/repository/conf/analytics/"
       volumes:
         - name: apim-analytics-storage-volume
           persistentVolumeClaim:

--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-1-deployment.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-1-deployment.yaml
@@ -118,12 +118,15 @@ spec:
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-datasources/"
           - name: apim-analytics-1-tomcat
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-tomcat/"
-          - name: apim-analytics-1-conf-analytics
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-analytics/"
+          - name: apim-analytics-1-conf-analytics-volume
+            mountPath: "/home/wso2user/wso2am-analytics-2.1.0/repository/conf/analytics"
       volumes:
         - name: apim-analytics-storage-volume
           persistentVolumeClaim:
-            claimName: apim-analytics-volume-claim-1
+            claimName: apim-analytics-data-volume-claim-1
+        - name: apim-analytics-1-conf-analytics-volume
+          persistentVolumeClaim:
+            claimName: apim-analytics-conf-volume-claim-1
         - name: apim-analytics-1-bin
           configMap:
             name: apim-analytics-1-bin
@@ -142,7 +145,4 @@ spec:
         - name: apim-analytics-1-tomcat
           configMap:
             name: apim-analytics-1-tomcat
-        - name: apim-analytics-1-conf-analytics
-          configMap:
-            name: apim-analytics-1-conf-analytics
       serviceAccountName: "wso2svcacct"

--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-1-deployment.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-1-deployment.yaml
@@ -118,12 +118,14 @@ spec:
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-datasources/"
           - name: apim-analytics-1-tomcat
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-tomcat/"
+          - name: apim-analytics-1-conf-analytics
+            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-analytics/"
           - name: apim-analytics-1-conf-analytics-volume
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0/repository/conf/analytics"
       volumes:
         - name: apim-analytics-storage-volume
           persistentVolumeClaim:
-            claimName: apim-analytics-data-volume-claim-1
+            claimName: apim-analytics-volume-claim-1
         - name: apim-analytics-1-conf-analytics-volume
           persistentVolumeClaim:
             claimName: apim-analytics-conf-volume-claim-1
@@ -145,4 +147,7 @@ spec:
         - name: apim-analytics-1-tomcat
           configMap:
             name: apim-analytics-1-tomcat
+        - name: apim-analytics-1-conf-analytics
+          configMap:
+            name: apim-analytics-1-conf-analytics
       serviceAccountName: "wso2svcacct"

--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-2-deployment.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-2-deployment.yaml
@@ -112,12 +112,14 @@ spec:
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-datasources/"
           - name: apim-analytics-2-tomcat
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-tomcat/"
+          - name: apim-analytics-2-conf-analytics
+            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-analytics/"
           - name: apim-analytics-2-conf-analytics-volume
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0/repository/conf/analytics/"
       volumes:
         - name: apim-analytics2-storage-volume
           persistentVolumeClaim:
-            claimName: apim-analytics-data-volume-claim-2
+            claimName: apim-analytics-volume-claim-2
         - name: apim-analytics-2-conf-analytics-volume
           persistentVolumeClaim:
             claimName: apim-analytics-conf-volume-claim-2

--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-2-deployment.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-2-deployment.yaml
@@ -112,12 +112,15 @@ spec:
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-datasources/"
           - name: apim-analytics-2-tomcat
             mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-tomcat/"
-          - name: apim-analytics-2-conf-analytics
-            mountPath: "/home/wso2user/wso2am-analytics-2.1.0-conf/conf-analytics/"
+          - name: apim-analytics-2-conf-analytics-volume
+            mountPath: "/home/wso2user/wso2am-analytics-2.1.0/repository/conf/analytics/"
       volumes:
         - name: apim-analytics2-storage-volume
           persistentVolumeClaim:
-            claimName: apim-analytics-volume-claim-2
+            claimName: apim-analytics-data-volume-claim-2
+        - name: apim-analytics-2-conf-analytics-volume
+          persistentVolumeClaim:
+            claimName: apim-analytics-conf-volume-claim-2
         - name: apim-analytics-2-bin
           configMap:
             name: apim-analytics-2-bin

--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-volume-claim.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-volume-claim.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: apim-analytics-data-volume-claim-1
+  name: apim-analytics-volume-claim-1
   labels:
     app: apim-analytics
     pattern: wso2apim-pattern-1
@@ -35,7 +35,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: apim-analytics-data-volume-claim-2
+  name: apim-analytics-volume-claim-2
   labels:
     app: apim-analytics
     pattern: wso2apim-pattern-1

--- a/pattern-1/artifacts/apim-analytics/wso2apim-analytics-volume-claim.yaml
+++ b/pattern-1/artifacts/apim-analytics/wso2apim-analytics-volume-claim.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: apim-analytics-volume-claim-1
+  name: apim-analytics-data-volume-claim-1
   labels:
     app: apim-analytics
     pattern: wso2apim-pattern-1
@@ -24,12 +24,38 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
+    # This storage size should be change according to the TPS of the server and the record count.
+      storage: 20Gi
+  selector:
+      matchLabels:
+        type: local
+        pattern: wso2apim-pattern-1
+        purpose: apim-analytics-data-1
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: apim-analytics-volume-claim-2
+  name: apim-analytics-data-volume-claim-2
+  labels:
+    app: apim-analytics
+    pattern: wso2apim-pattern-1
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+        # This storage size should be change according to the TPS of the server and the record count.
+      storage: 20Gi
+  selector:
+    matchLabels:
+      type: local
+      pattern: wso2apim-pattern-1
+      purpose: apim-analytics-data-2
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: apim-analytics-conf-volume-claim-1
   labels:
     app: apim-analytics
     pattern: wso2apim-pattern-1
@@ -39,3 +65,27 @@ spec:
   resources:
     requests:
       storage: 1Gi
+  selector:
+    matchLabels:
+      type: local
+      pattern: wso2apim-pattern-1
+      purpose: apim-analytics-conf-analytics-1
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: apim-analytics-conf-volume-claim-2
+  labels:
+    app: apim-analytics
+    pattern: wso2apim-pattern-1
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  selector:
+    matchLabels:
+      type: local
+      pattern: wso2apim-pattern-1
+      purpose: apim-analytics-conf-analytics-2

--- a/pattern-1/artifacts/volumes/persistent-volumes.yaml
+++ b/pattern-1/artifacts/volumes/persistent-volumes.yaml
@@ -12,25 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: local-pv-1
-  labels:
-    type: local
-    pattern: wso2apim-pattern-1
-spec:
-  capacity:
-    storage: 1Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Recycle
-  nfs:
-    # FIXME: use the right IP
-    #Example Path in NFS server: /exports/pattern-1/anlytics2
-    server: <NFS-Server-IP>
-    path: "<NFS location path>"
----
+
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -50,25 +32,6 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: local-pv-3
-  labels:
-    type: local
-    pattern: wso2apim-pattern-1
-spec:
-  capacity:
-    storage: 2Gi
-  accessModes:
-    - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Delete
-  nfs:
-  # FIXME: use the right IP
-  #Example Path in NFS server: /exports/pattern-1/anlytics2
-    server: <NFS-Server-IP>
-    path: "<NFS location path>"
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
   name: local-pv-4
   labels:
     type: local
@@ -82,5 +45,85 @@ spec:
   nfs:
   # FIXME: use the right IP
   #Example Path in NFS server: /exports/pattern-1/apim
+    server: <NFS-Server-IP>
+    path: "<NFS location path>"
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv-1
+  labels:
+    type: local
+    pattern: wso2apim-pattern-1
+    purpose: apim-analytics-conf-analytics-1
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  nfs:
+    # FIXME: use the right IP
+    #Example Path in NFS server: /exports/pattern-1/anlytics2
+    server: <NFS-Server-IP>
+    path: "<NFS location path>"
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv-1
+  labels:
+    type: local
+    pattern: wso2apim-pattern-1
+    purpose: apim-analytics-conf-analytics-2
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  nfs:
+    # FIXME: use the right IP
+    #Example Path in NFS server: /exports/pattern-1/anlytics2
+    server: <NFS-Server-IP>
+    path: "<NFS location path>"
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv-1
+  labels:
+    type: local
+    pattern: wso2apim-pattern-1
+    purpose: apim-analytics-data-1
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  nfs:
+    # FIXME: use the right IP
+    #Example Path in NFS server: /exports/pattern-1/anlytics2
+    server: <NFS-Server-IP>
+    path: "<NFS location path>"
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-pv-1
+  labels:
+    type: local
+    pattern: wso2apim-pattern-1
+    purpose: apim-analytics-data-2
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  nfs:
+    # FIXME: use the right IP
+    #Example Path in NFS server: /exports/pattern-1/anlytics2
     server: <NFS-Server-IP>
     path: "<NFS location path>"

--- a/pattern-1/artifacts/volumes/persistent-volumes.yaml
+++ b/pattern-1/artifacts/volumes/persistent-volumes.yaml
@@ -63,15 +63,15 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Recycle
   nfs:
-    # FIXME: use the right IP
-    #Example Path in NFS server: /exports/pattern-1/anlytics2
+  # FIXME: use the right IP
+  #Example Path in NFS server: /exports/pattern-1/anlytics2
     server: <NFS-Server-IP>
     path: "<NFS location path>"
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: local-pv-1
+  name: local-pv-3
   labels:
     type: local
     pattern: wso2apim-pattern-1
@@ -83,15 +83,15 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Recycle
   nfs:
-    # FIXME: use the right IP
-    #Example Path in NFS server: /exports/pattern-1/anlytics2
+  # FIXME: use the right IP
+  #Example Path in NFS server: /exports/pattern-1/anlytics2
     server: <NFS-Server-IP>
     path: "<NFS location path>"
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: local-pv-1
+  name: local-pv-5
   labels:
     type: local
     pattern: wso2apim-pattern-1
@@ -103,15 +103,15 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Recycle
   nfs:
-    # FIXME: use the right IP
-    #Example Path in NFS server: /exports/pattern-1/anlytics2
+  # FIXME: use the right IP
+  #Example Path in NFS server: /exports/pattern-1/anlytics2
     server: <NFS-Server-IP>
     path: "<NFS location path>"
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: local-pv-1
+  name: local-pv-6
   labels:
     type: local
     pattern: wso2apim-pattern-1
@@ -123,7 +123,7 @@ spec:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Recycle
   nfs:
-    # FIXME: use the right IP
-    #Example Path in NFS server: /exports/pattern-1/anlytics2
+  # FIXME: use the right IP
+  #Example Path in NFS server: /exports/pattern-1/anlytics2
     server: <NFS-Server-IP>
     path: "<NFS location path>"


### PR DESCRIPTION
## Purpose
> This will allow users to mount repository/conf/analytics folder to NFS server which is required to run APIM Analytics. So that indexing will not be affected when the server restarts. 
