### PR TITLE
Fix the volume mount path

### DIFF
--- a/helm/pattern-1/apim-with-analytics/templates/wso2apim-deployment.yaml
+++ b/helm/pattern-1/apim-with-analytics/templates/wso2apim-deployment.yaml
@@ -86,7 +86,7 @@ spec:
           protocol: "TCP"
         volumeMounts:
         - name: apim-storage-volume
-          mountPath: /home/wso2carbon/wso2am-2.5.0/repository/deployment/server
+          mountPath: /home/wso2carbon/wso2am-2.6.0/repository/deployment/server
         - name: apim-conf
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
         - name: apim-conf-datasources


### PR DESCRIPTION
## Purpose
>  The current volume mount path for the APIM is incorrect in the Helm pattern-1. This PR adds the correct volume mount path for the APIM.

fixes #166