### PR TITLE
Ignore imagePullCredentials when using public docker images

### DIFF
--- a/advanced/helm/pattern-1/apim-with-analytics/templates/wso2apim-analytics-deployment.yaml
+++ b/advanced/helm/pattern-1/apim-with-analytics/templates/wso2apim-analytics-deployment.yaml
@@ -91,8 +91,10 @@ spec:
         - name: apim-analytics-conf-worker
           mountPath: /home/wso2carbon/wso2-config-volume/conf/worker
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
       imagePullSecrets:
       - name: wso2creds
+      {{ end }}
       volumes:
       - name: apim-analytics-conf-worker
         configMap:

--- a/advanced/helm/pattern-1/apim-with-analytics/templates/wso2apim-deployment.yaml
+++ b/advanced/helm/pattern-1/apim-with-analytics/templates/wso2apim-deployment.yaml
@@ -96,8 +96,10 @@ spec:
             - name: apim-conf-datasources
               mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/datasources
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
       imagePullSecrets:
-        - name: wso2creds
+      - name: wso2creds
+      {{ end }}
       volumes:
         - name: apim-storage-volume
           persistentVolumeClaim:

--- a/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-analytics-deployment.yaml
+++ b/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-analytics-deployment.yaml
@@ -91,8 +91,10 @@ spec:
         - name: apim-analytics-conf-worker
           mountPath: /home/wso2carbon/wso2-config-volume/conf/worker
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
       imagePullSecrets:
       - name: wso2creds
+      {{ end }}
       volumes:
       - name: apim-analytics-conf-worker
         configMap:

--- a/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-gateway-deployment.yaml
+++ b/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-gateway-deployment.yaml
@@ -100,8 +100,10 @@ spec:
         - name: apim-gateway-conf-identity
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/identity
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
       imagePullSecrets:
       - name: wso2creds
+      {{ end }}
       volumes:
       - name: apim-storage-volume
         persistentVolumeClaim:

--- a/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-is-as-km-deployment.yaml
+++ b/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-is-as-km-deployment.yaml
@@ -77,8 +77,10 @@ spec:
         - name: apim-is-as-km-conf-datasources
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/datasources
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
       imagePullSecrets:
       - name: wso2creds
+      {{ end }}
       volumes:
       - name: apim-is-as-km-storage-volume
         persistentVolumeClaim:

--- a/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-pubstore-tm-1-deployment.yaml
+++ b/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-pubstore-tm-1-deployment.yaml
@@ -99,8 +99,10 @@ spec:
         - name: apim-pubstore-tm-1-conf-identity
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/identity
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
       imagePullSecrets:
       - name: wso2creds
+      {{ end }}
       volumes:
       - name: apim-pubstore-tm-1-conf
         configMap:

--- a/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-pubstore-tm-2-deployment.yaml
+++ b/advanced/helm/pattern-2/apim-gw-km-with-analytics/templates/wso2apim-pubstore-tm-2-deployment.yaml
@@ -99,8 +99,10 @@ spec:
         - name: apim-pubstore-tm-2-conf-identity
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/identity
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
       imagePullSecrets:
       - name: wso2creds
+      {{ end }}
       volumes:
       - name: apim-pubstore-tm-2-conf
         configMap:


### PR DESCRIPTION
## Purpose
The secret "wso2creds" is not created if username and password aren't given as values for the helm charts. However the deployment manifest contains reference(imagePullCredentials) to the above mentioned secret. The fix is to use the same conditional check used in the secret to ignore the imagePullCredentials in the deployment manifests when the secret is not created.