### PR TITLE
Correct invalid variable substitution

### DIFF
--- a/simple/single-script/create/funcs
+++ b/simple/single-script/create/funcs
@@ -281,7 +281,7 @@ function deploy(){
 
     # replace necessary variables
     sed -i.bak 's/"$ns.k8s.&.wso2.apim"/'$namespace'/g' $k8s_obj_file
-    sed -i.bak 's/"$string.&.secret.auth.data"/'$secdata'/g' $k8s_obj_file
+    sed -i.bak 's/"$string.&.secret.auth.data"/'$str_sec'/g' $k8s_obj_file
     sed -i.bak 's/"ip.node.k8s.&.wso2.apim"/'$NODE_IP'/g' $k8s_obj_file
     sed -i.bak 's/"$nodeport.k8s.&.1.wso2apim"/'$NP_1'/g' $k8s_obj_file
     sed -i.bak 's/"$nodeport.k8s.&.2.wso2apim"/'$NP_2'/g' $k8s_obj_file

--- a/simple/single-script/create/funcs4opensource
+++ b/simple/single-script/create/funcs4opensource
@@ -245,7 +245,6 @@ function deploy(){
 
     # replace necessary variables
     sed -i.bak 's/"$ns.k8s.&.wso2.apim"/'$namespace'/g' $k8s_obj_file
-    sed -i.bak 's/"$string.&.secret.auth.data"/'$secdata'/g' $k8s_obj_file
     sed -i.bak 's/"ip.node.k8s.&.wso2.apim"/'$NODE_IP'/g' $k8s_obj_file
     sed -i.bak 's/"$nodeport.k8s.&.1.wso2apim"/'$NP_1'/g' $k8s_obj_file
     sed -i.bak 's/"$nodeport.k8s.&.2.wso2apim"/'$NP_2'/g' $k8s_obj_file

--- a/simple/single-script/wso2am-ga.sh
+++ b/simple/single-script/wso2am-ga.sh
@@ -19,7 +19,7 @@
 set -e
 
 # bash variables
-k8s_obj_file="deployment.yaml"; NODE_IP=''; str_sec=""
+k8s_obj_file="deployment.yaml"; NODE_IP='';
 
 # wso2 subscription variables
 WUMUsername=''; WUMPassword=''
@@ -3392,7 +3392,6 @@ function deploy(){
 
     # replace necessary variables
     sed -i.bak 's/"$ns.k8s.&.wso2.apim"/'$namespace'/g' $k8s_obj_file
-    sed -i.bak 's/"$string.&.secret.auth.data"/'$secdata'/g' $k8s_obj_file
     sed -i.bak 's/"ip.node.k8s.&.wso2.apim"/'$NODE_IP'/g' $k8s_obj_file
     sed -i.bak 's/"$nodeport.k8s.&.1.wso2apim"/'$NP_1'/g' $k8s_obj_file
     sed -i.bak 's/"$nodeport.k8s.&.2.wso2apim"/'$NP_2'/g' $k8s_obj_file

--- a/simple/single-script/wso2am-latest.sh
+++ b/simple/single-script/wso2am-latest.sh
@@ -3437,7 +3437,7 @@ function deploy(){
 
     # replace necessary variables
     sed -i.bak 's/"$ns.k8s.&.wso2.apim"/'$namespace'/g' $k8s_obj_file
-    sed -i.bak 's/"$string.&.secret.auth.data"/'$secdata'/g' $k8s_obj_file
+    sed -i.bak 's/"$string.&.secret.auth.data"/'$str_sec'/g' $k8s_obj_file
     sed -i.bak 's/"ip.node.k8s.&.wso2.apim"/'$NODE_IP'/g' $k8s_obj_file
     sed -i.bak 's/"$nodeport.k8s.&.1.wso2apim"/'$NP_1'/g' $k8s_obj_file
     sed -i.bak 's/"$nodeport.k8s.&.2.wso2apim"/'$NP_2'/g' $k8s_obj_file


### PR DESCRIPTION
## Purpose
> Resources for simplified kubernetes-apim are not deploying due to a syntax error in sed command in Ubuntu. 

## Goals
> Ubuntu creates line breaks in long string variables as "secdata". Correct line breaks in secdata variable by using an improved variable "str_sec"