### PR TITLE
single deployment link not availale

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ of WSO2 API Manager.*
 
 ### Simple
 
-* [Deployment Single Node](simple/single-script/README.md)
+* [Deployment Single Node](simple/README.md)
 
 ### Advanced
 


### PR DESCRIPTION
## Purpose
> The single deployment link directs to page not found. Now replaced with the exact link.

