### PR TITLE
[v2.6.x] Promote Helm resources as the primary and single source of Kubernetes resource installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ of WSO2 API Manager.*
 
 ### Advanced
 
+**Note**: We consider Helm to be the primary source of installation of WSO2 product deployment patterns in Kubernetes environments. Hence, pure Kubernetes resources for product deployment patterns will be deprecated from 2.6.0.7 onwards. Please adjust your usage accordingly.
+
 * [Deployment Pattern 1](advanced/pattern-1/README.md)
 * [Deployment Pattern 2](advanced/pattern-2/README.md)
 * [Deployment Pattern 3](advanced/pattern-3/README.md)
@@ -27,7 +29,7 @@ of WSO2 API Manager.*
 
 ## Changelog
 
-**Change log** from previous v2.6.0.7 release: [View Here](CHANGELOG.md)
+**Change log** from previous v2.6.0.6 release: [View Here](CHANGELOG.md)
 
 ## Reporting issues
 

--- a/advanced/pattern-1/README.md
+++ b/advanced/pattern-1/README.md
@@ -1,5 +1,7 @@
 # Kubernetes Resources for deployment of WSO2 API Manager with WSO2 API Manager Analytics
 
+**Note**: We consider Helm to be the primary source of installation of WSO2 product deployment patterns in Kubernetes environments. Hence, pure Kubernetes resources for product deployment patterns will be deprecated from 2.6.0.7 onwards. Please adjust your usage accordingly.
+
 Core Kubernetes resources for [WSO2 API Manager deployment pattern 1](https://docs.wso2.com/display/AM220/Deployment+Patterns#DeploymentPatterns-Pattern1).
 This is a deployment of WSO2 API Manager with WSO2 API Manager Analytics support.
 

--- a/advanced/pattern-2/README.md
+++ b/advanced/pattern-2/README.md
@@ -1,5 +1,7 @@
 # Kubernetes Resources for deployment of WSO2 API Manager with a separate Gateway and a separate Key Manager
 
+**Note**: We consider Helm to be the primary source of installation of WSO2 product deployment patterns in Kubernetes environments. Hence, pure Kubernetes resources for product deployment patterns will be deprecated from 2.6.0.7 onwards. Please adjust your usage accordingly.
+
 Core Kubernetes resources for [WSO2 API Manager deployment pattern 2](https://docs.wso2.com/display/AM220/Deployment+Patterns#DeploymentPatterns-Pattern2).
 This consists of a deployment of WSO2 API Manager with a separate Gateway and a separate Key Manager along with WSO2 API Manager Analytics support.
 

--- a/advanced/pattern-3/README.md
+++ b/advanced/pattern-3/README.md
@@ -1,5 +1,7 @@
 # Kubernetes Resources for a Fully Distributed deployment of WSO2 API Manager
 
+**Note**: We consider Helm to be the primary source of installation of WSO2 product deployment patterns in Kubernetes environments. Hence, pure Kubernetes resources for product deployment patterns will be deprecated from 2.6.0.7 onwards. Please adjust your usage accordingly.
+
 Core Kubernetes resources for [WSO2 API Manager deployment pattern 3](https://docs.wso2.com/display/AM260/Deployment+Patterns#DeploymentPatterns-Pattern3).
 This consists of a fully distributed deployment of WSO2 API Manager with WSO2 API Manager Analytics support.
 


### PR DESCRIPTION
## Purpose
> This PR removes the pure Kubernetes resources for WSO2 API Management deployment patterns with the purpose of promoting Helm resources as the primary and single source of Kubernetes resource installation. This fixes https://github.com/wso2/kubernetes-apim/issues/271.

## Goals
> [v2.6.x] Promote Helm resources as the primary and single source of Kubernetes resource installation