### PR TITLE
[v2.6.x] Add persistent volumes to synapse-configs and executionplans pattern-1

### DIFF
--- a/advanced/pattern-1/apim/wso2apim-1-deployment.yaml
+++ b/advanced/pattern-1/apim/wso2apim-1-deployment.yaml
@@ -87,17 +87,22 @@ spec:
           containerPort: 9443
           protocol: "TCP"
         volumeMounts:
-        - name: apim-storage-volume
-          mountPath: /home/wso2carbon/wso2am-2.6.0/repository/deployment/server
+        - name: apim-synapse-configs-volume
+          mountPath: /home/wso2carbon/wso2am-2.6.0/repository/deployment/server/synapse-configs
+        - name: apim-execution-plans-volume
+          mountPath: /home/wso2carbon/wso2am-2.6.0/repository/deployment/server/executionplans
         - name: apim-1-conf
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
         - name: apim-1-conf-datasources
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/datasources
       serviceAccountName: "wso2svc-account"
       volumes:
-      - name: apim-storage-volume
+      - name: apim-synapse-configs-volume
         persistentVolumeClaim:
-          claimName: wso2apim-with-analytics-apim-deployment-volume-claim
+          claimName: wso2apim-with-analytics-apim-synapse-configs-volume-claim
+      - name: apim-execution-plans-volume
+        persistentVolumeClaim:
+          claimName: wso2apim-with-analytics-apim-execution-plans-volume-claim
       - name: apim-1-conf
         configMap:
           name: apim-1-conf

--- a/advanced/pattern-1/apim/wso2apim-2-deployment.yaml
+++ b/advanced/pattern-1/apim/wso2apim-2-deployment.yaml
@@ -90,17 +90,22 @@ spec:
           containerPort: 9443
           protocol: "TCP"
         volumeMounts:
-        - name: apim-storage-volume
-          mountPath: /home/wso2carbon/wso2am-2.6.0/repository/deployment/server
+        - name: apim-synapse-configs-volume
+          mountPath: /home/wso2carbon/wso2am-2.6.0/repository/deployment/server/synapse-configs
+        - name: apim-execution-plans-volume
+          mountPath: /home/wso2carbon/wso2am-2.6.0/repository/deployment/server/executionplans
         - name: apim-2-conf
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
         - name: apim-2-conf-datasources
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/datasources
       serviceAccountName: "wso2svc-account"
       volumes:
-      - name: apim-storage-volume
+      - name: apim-synapse-configs-volume
         persistentVolumeClaim:
-          claimName: wso2apim-with-analytics-apim-deployment-volume-claim
+          claimName: wso2apim-with-analytics-apim-synapse-configs-volume-claim
+      - name: apim-execution-plans-volume
+        persistentVolumeClaim:
+          claimName: wso2apim-with-analytics-apim-execution-plans-volume-claim
       - name: apim-2-conf
         configMap:
           name: apim-2-conf

--- a/advanced/pattern-1/apim/wso2apim-volume-claim.yaml
+++ b/advanced/pattern-1/apim/wso2apim-volume-claim.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: wso2apim-with-analytics-apim-deployment-volume-claim
+  name: wso2apim-with-analytics-apim-synapse-configs-volume-claim
 spec:
   accessModes:
     - ReadWriteMany
@@ -25,4 +25,21 @@ spec:
   storageClassName: ""
   selector:
     matchLabels:
-      purpose: apim-shared-deployment
+      purpose: apim-synapse-configs
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wso2apim-with-analytics-apim-execution-plans-volume-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ""
+  selector:
+    matchLabels:
+      purpose: apim-execution-plans
+      

--- a/advanced/pattern-1/apim/wso2apim-volume-claim.yaml
+++ b/advanced/pattern-1/apim/wso2apim-volume-claim.yaml
@@ -42,4 +42,3 @@ spec:
   selector:
     matchLabels:
       purpose: apim-execution-plans
-      

--- a/advanced/pattern-1/volumes/persistent-volumes.yaml
+++ b/advanced/pattern-1/volumes/persistent-volumes.yaml
@@ -11,13 +11,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+ 
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: wso2apim-with-analytics-shared-synapse-configs-pv
+  labels:
+    purpose: apim-synapse-configs
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: <NFS_SERVER_IP>
+    path: "<NFS_LOCATION_PATH>"
+
+---
 
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: wso2apim-with-analytics-shared-deployment-pv
+  name: wso2apim-with-analytics-shared-execution-plans-pv
   labels:
-    purpose: apim-shared-deployment
+    purpose: apim-execution-plans
 spec:
   capacity:
     storage: 1Gi


### PR DESCRIPTION
# Purpose
This PR adds two persistent volumes to synapse-configs and executionplans in pattern-1. This fixes #275.

# Goals
[v2.6.x] Adds two persistent volumes to synapse-configs and executionplans in pattern-1