### PR TITLE
Use backend protocol HTTPS and disable SSL-passthrough for ingress

### DIFF
--- a/advanced/am-pattern-1/README.md
+++ b/advanced/am-pattern-1/README.md
@@ -20,7 +20,7 @@
 * An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup/pick-right-solution/).<br><br>
 
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/). Please note that Helm resources for WSO2 product
-  deployment patterns are compatible with NGINX Ingress Controller Git release [`nginx-0.22.0`](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.22.0).
+  deployment patterns are compatible with NGINX Ingress Controller Git release [`nginx-0.26.1`](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.26.1).
 
 * Add the WSO2 Helm chart repository.
 

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace : {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
   tls:
     - hosts:

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-gateway-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-gateway-ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace : {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
   tls:
   - hosts:

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace : {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"


### PR DESCRIPTION
## Purpose
The current implementation of the NGINX ingress resources does not work with the NGINX versions later than 0.22.0 (#298  ). This PR introduces the following changes to add support for this.

- Add annotation `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` to force the backend protocol to be HTTPS.
- Remove annotation `nginx.ingress.kubernetes.io/ssl-passthrough: "true"`
