### PR TITLE
[v3.1.x] Integrate Support For Automatic Rolling Update Upon ConfigMap Changes

### DIFF
--- a/advanced/am-pattern-1/templates/_helpers.tpl
+++ b/advanced/am-pattern-1/templates/_helpers.tpl
@@ -15,31 +15,51 @@ limitations under the License.
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "apim-with-analytics-conf.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "am-pattern-1.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "apim-with-analytics-conf.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- define "am-pattern-1.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "apim-with-analytics-conf.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- define "am-pattern-1.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "am-pattern-1.labels" -}}
+app.kubernetes.io/name: {{ include "am-pattern-1.name" . }}
+helm.sh/chart: {{ include "am-pattern-1.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Common prefix prepended to Kubernetes resources of this chart
+*/}}
+{{- define "am-pattern-1.resource.prefix" -}}
+{{- "wso2am-pattern-1" }}
 {{- end -}}

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-bin.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-bin.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: wso2am-pattern-1-am-analytics-dashboard-bin
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-bin
   namespace : {{ .Release.Namespace }}
 data:
   carbon.sh: |-

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-conf.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-conf.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: wso2am-pattern-1-am-analytics-dashboard-conf
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-conf
   namespace : {{ .Release.Namespace }}
   {{ if .Values.wso2.deployment.analytics.dashboard.config }}
 
@@ -416,9 +416,9 @@ data:
         allScopes: apim_analytics:admin apim_analytics:product_manager apim_analytics:api_developer apim_analytics:app_developer apim_analytics:devops_engineer apim_analytics:analytics_viewer apim_analytics:everyone openid apim:api_view apim:subscribe
         adminUsername: admin
         adminPassword: admin
-        kmDcrUrl: https://wso2am-pattern-1-am-service:9443/client-registration/v0.16/register
+        kmDcrUrl: https://{{ template "am-pattern-1.resource.prefix" . }}-am-service:9443/client-registration/v0.16/register
         kmTokenUrlForRedirection: https://{{ .Values.wso2.deployment.am.hostname }}/oauth2
-        kmTokenUrl: https://wso2am-pattern-1-am-service:9443/oauth2
+        kmTokenUrl: https://{{ template "am-pattern-1.resource.prefix" . }}-am-service:9443/oauth2
         kmUsername: admin
         kmPassword: admin
         portalAppContext: analytics-dashboard
@@ -426,8 +426,8 @@ data:
         cacheTimeout: 30
         baseUrl: https://{{ .Values.wso2.deployment.analytics.dashboard.hostname }}
         grantType: authorization_code
-        publisherUrl: https://wso2am-pattern-1-am-service:9443
-        devPortalUrl: https://wso2am-pattern-1-am-service:9443
+        publisherUrl: https://{{ template "am-pattern-1.resource.prefix" . }}-am-service:9443
+        devPortalUrl: https://{{ template "am-pattern-1.resource.prefix" . }}-am-service:9443
         externalLogoutUrl: https://{{ .Values.wso2.deployment.am.hostname }}/oidc/logout
 
     wso2.dashboard:

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-deployment.yaml
@@ -29,6 +29,9 @@ spec:
       deployment: wso2am-pattern-1-analytics-dashboard
   template:
     metadata:
+      annotations:
+        checksum.am.analytics.dashboard.bin: {{ include (print $.Template.BasePath "/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-bin.yaml") . | sha256sum }}
+        checksum.am.analytics.dashboard.conf: {{ include (print $.Template.BasePath "/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-conf.yaml") . | sha256sum }}
       labels:
         deployment: wso2am-pattern-1-analytics-dashboard
     spec:

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wso2am-pattern-1-am-analytics-dashboard-deployment
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-deployment
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.wso2.deployment.analytics.dashboard.replicas }}
@@ -26,14 +26,14 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      deployment: wso2am-pattern-1-analytics-dashboard
+      deployment: {{ template "am-pattern-1.resource.prefix" . }}-analytics-dashboard
   template:
     metadata:
       annotations:
         checksum.am.analytics.dashboard.bin: {{ include (print $.Template.BasePath "/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-bin.yaml") . | sha256sum }}
         checksum.am.analytics.dashboard.conf: {{ include (print $.Template.BasePath "/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-conf.yaml") . | sha256sum }}
       labels:
-        deployment: wso2am-pattern-1-analytics-dashboard
+        deployment: {{ template "am-pattern-1.resource.prefix" . }}-analytics-dashboard
     spec:
       {{ if .Values.wso2.deployment.dependencies.mysql }}
       initContainers:
@@ -96,29 +96,29 @@ spec:
             - containerPort: 7613
               protocol: "TCP"
           volumeMounts:
-            - name: wso2am-pattern-1-am-analytics-dashboard-conf
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-conf
               mountPath: /home/wso2carbon/wso2-config-volume/conf/dashboard/deployment.yaml
               subPath: deployment.yaml
-            - name: wso2am-pattern-1-am-analytics-dashboard-bin
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-bin
               mountPath: /home/wso2carbon/wso2-config-volume/wso2/dashboard/bin/carbon.sh
               subPath: carbon.sh
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
       {{- if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
-        - name: wso2am-pattern-1-wso2-private-registry-creds
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-wso2-private-registry-creds
       {{- end }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:
         - name: {{ .Values.wso2.deployment.am.imagePullSecrets }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
-        - name: wso2am-pattern-1-wso2-private-registry-creds
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-wso2-private-registry-creds
       {{- end }}
       volumes:
-        - name: wso2am-pattern-1-am-analytics-dashboard-conf
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-conf
           configMap:
-            name: wso2am-pattern-1-am-analytics-dashboard-conf
-        - name: wso2am-pattern-1-am-analytics-dashboard-bin
+            name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-conf
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-bin
           configMap:
-            name: wso2am-pattern-1-am-analytics-dashboard-bin
+            name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-bin
             defaultMode: 0407

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-ingress.yaml
@@ -15,7 +15,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: wso2am-pattern-1-am-analytics-dashboard-ingress
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-ingress
   namespace : {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
@@ -30,5 +30,5 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: wso2am-pattern-1-am-analytics-dashboard-service
+              serviceName: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-service
               servicePort: 9643

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-service.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-service.yaml
@@ -15,12 +15,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: wso2am-pattern-1-am-analytics-dashboard-service
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-service
   namespace : {{ .Release.Namespace }}
 spec:
   # label keys and values that must match in order to receive traffic for this service
   selector:
-    deployment: wso2am-pattern-1-analytics-dashboard
+    deployment: {{ template "am-pattern-1.resource.prefix" . }}-analytics-dashboard
   ports:
     # ports that this service should serve on
     -

--- a/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-1-am-analytics-worker-conf.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-1-am-analytics-worker-conf.yaml
@@ -424,41 +424,6 @@ data:
               validationTimeout: 30000
               isAutoCommit: false
 
-        #Main datasource used in API Manager
-        - name: AM_DB
-          description: Main datasource used by API Manager
-          jndiConfig:
-            name: jdbc/AM_DB
-          definition:
-            type: RDBMS
-            configuration:
-              jdbcUrl: "jdbc:mysql://wso2am-mysql-db-service:3306/WSO2AM_DB?useSSL=false&allowPublicKeyRetrieval=true"
-              username: wso2carbon
-              password: wso2carbon
-              driverClassName: com.mysql.cj.jdbc.Driver
-              maxPoolSize: 10
-              idleTimeout: 60000
-              connectionTestQuery: SELECT 1
-              validationTimeout: 30000
-              isAutoCommit: false
-
-        - name: WSO2AM_MGW_ANALYTICS_DB
-          description: "The datasource used for APIM MGW analytics data."
-          jndiConfig:
-            name: jdbc/WSO2AM_MGW_ANALYTICS_DB
-          definition:
-            type: RDBMS
-            configuration:
-              jdbcUrl: 'jdbc:h2:${sys:carbon.home}/wso2/worker/database/WSO2AM_MGW_ANALYTICS_DB;AUTO_SERVER=TRUE'
-              username: wso2carbon
-              password: wso2carbon
-              driverClassName: org.h2.Driver
-              maxPoolSize: 50
-              idleTimeout: 60000
-              connectionTestQuery: SELECT 1
-              validationTimeout: 30000
-              isAutoCommit: false
-
         - name: WSO2_CLUSTER_DB
           description: The MySQL datasource used for Cluster Coordination
           jndiConfig:
@@ -494,6 +459,9 @@ data:
               isAutoCommit: false
 
     siddhi:
+      # properties:
+      #  partitionById: true
+      #  shardId: 1
       refs:
         - ref:
             name: 'grpcSource'
@@ -563,6 +531,10 @@ data:
                 id: 1
                 displayName: admin
 
+    # Configuration to enable apim alerts
+    #analytics.solutions:
+    #  APIM-alerts.enabled: true
+
       # Sample of deployment.config for Two node HA
     deployment.config:
       type: ha
@@ -584,5 +556,23 @@ data:
         maxWait: 60000
         minEvictableIdleTimeMillis: 120000
 
+    # Sample of deployment.config for Distributed deployment
+    #deployment.config:
+    #  type: distributed
+    #  httpsInterface:
+    #    host: 192.168.1.3
+    #    port: 9443
+    #    username: admin
+    #    password: admin
+    #  leaderRetryInterval: 10000
+    #  resourceManagers:
+    #    - host: 192.168.1.1
+    #      port: 9543
+    #      username: admin
+    #      password: admin
+    #    - host: 192.168.1.2
+    #      port: 9543
+    #      username: admin
+    #      password: admin
 
   {{- end }}

--- a/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-1-am-analytics-worker-conf.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-1-am-analytics-worker-conf.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: wso2am-pattern-1-am-analytics-worker-conf
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-conf
   namespace : {{ .Release.Namespace }}
   {{ if .Values.wso2.deployment.analytics.worker.config }}
 

--- a/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-1-am-analytics-worker-service.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-1-am-analytics-worker-service.yaml
@@ -15,12 +15,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: wso2am-pattern-1-analytics-worker-service
+  name: {{ template "am-pattern-1.resource.prefix" . }}-analytics-worker-service
   namespace : {{ .Release.Namespace }}
 spec:
   # label keys and values that must match in order to receive traffic for this service
   selector:
-    deployment: wso2am-pattern-1-analytics-worker
+    deployment: {{ template "am-pattern-1.resource.prefix" . }}-analytics-worker
   ports:
     # ports that this service should serve on
     -

--- a/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-3-am-analytics-worker-headless-service.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-3-am-analytics-worker-headless-service.yaml
@@ -15,13 +15,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: wso2am-pattern-1-am-analytics-worker-headless-service
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service
   namespace: {{ .Release.Namespace }}
 spec:
   # label keys and values that must match in order to receive traffic for this service
   clusterIP: None
   selector:
-    deployment: wso2am-pattern-1-analytics-worker
+    deployment: {{ template "am-pattern-1.resource.prefix" . }}-analytics-worker
   ports:
     # ports that this service should serve on
     -

--- a/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-3-am-analytics-worker-statefulset.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-3-am-analytics-worker-statefulset.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: wso2am-pattern-1-am-analytics-worker-statefulset
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-statefulset
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 2
@@ -23,14 +23,14 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      deployment: wso2am-pattern-1-analytics-worker
-  serviceName: wso2am-pattern-1-am-analytics-worker-headless-service
+      deployment: {{ template "am-pattern-1.resource.prefix" . }}-analytics-worker
+  serviceName: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service
   template:
     metadata:
       annotations:
         checksum.am.analytics.worker.conf: {{ include (print $.Template.BasePath "/am-analytics/worker/wso2am-pattern-1-am-analytics-worker-conf.yaml") . | sha256sum }}
       labels:
-        deployment: wso2am-pattern-1-analytics-worker
+        deployment: {{ template "am-pattern-1.resource.prefix" . }}-analytics-worker
     spec:
       {{ if .Values.wso2.deployment.dependencies.mysql }}
       initContainers:
@@ -104,7 +104,7 @@ spec:
             - containerPort: 7444
               protocol: "TCP"
           volumeMounts:
-            - name: wso2am-pattern-1-am-analytics-worker-conf
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-conf
               mountPath: /home/wso2carbon/wso2-config-volume/conf/worker/deployment.yaml
               subPath: deployment.yaml
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
@@ -113,9 +113,9 @@ spec:
         - name: {{ .Values.wso2.deployment.am.imagePullSecrets }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
-        - name: wso2am-pattern-1-wso2-private-registry-creds
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-wso2-private-registry-creds
       {{- end }}
       volumes:
-        - name: wso2am-pattern-1-am-analytics-worker-conf
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-conf
           configMap:
-            name: wso2am-pattern-1-am-analytics-worker-conf
+            name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-conf

--- a/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-3-am-analytics-worker-statefulset.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-3-am-analytics-worker-statefulset.yaml
@@ -27,6 +27,8 @@ spec:
   serviceName: wso2am-pattern-1-am-analytics-worker-headless-service
   template:
     metadata:
+      annotations:
+        checksum.am.analytics.worker.conf: {{ include (print $.Template.BasePath "/am-analytics/worker/wso2am-pattern-1-am-analytics-worker-conf.yaml") . | sha256sum }}
       labels:
         deployment: wso2am-pattern-1-analytics-worker
     spec:

--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-1-conf.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-1-conf.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: wso2am-pattern-1-am-1-conf
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-1-conf
   namespace : {{ .Release.Namespace }}
   {{ if .Values.wso2.deployment.am.instanceOne.config }}
 
@@ -84,11 +84,11 @@ data:
 
     [apim.analytics]
     enable = true
-    store_api_url = "https://wso2am-pattern-1-analytics-worker-service:7444"
+    store_api_url = "https://{{ template "am-pattern-1.resource.prefix" . }}-analytics-worker-service:7444"
 
     [[apim.analytics.url_group]]
-    analytics_url =["tcp://wso2am-pattern-1-am-analytics-worker-statefulset-0.wso2am-pattern-1-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7612","tcp://wso2am-pattern-1-am-analytics-worker-statefulset-1.wso2am-pattern-1-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7612"]
-    analytics_auth_url =["ssl://wso2am-pattern-1-am-analytics-worker-statefulset-0.wso2am-pattern-1-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7712","ssl://wso2am-pattern-1-am-analytics-worker-statefulset-1.wso2am-pattern-1-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7712"]
+    analytics_url =["tcp://{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-statefulset-0.{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7612","tcp://{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-statefulset-1.{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7612"]
+    analytics_auth_url =["ssl://{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-statefulset-0.{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7712","ssl://{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-statefulset-1.{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7712"]
     type = "failover"
 
     [apim.devportal]
@@ -114,8 +114,8 @@ data:
     type = "loadbalance"
 
     [[apim.throttling.url_group]]
-    traffic_manager_urls = ["tcp://wso2am-pattern-1-am-2-service:9611"]
-    traffic_manager_auth_urls = ["ssl://wso2am-pattern-1-am-2-service:9711"]
+    traffic_manager_urls = ["tcp://{{ template "am-pattern-1.resource.prefix" . }}-am-2-service:9611"]
+    traffic_manager_auth_urls = ["ssl://{{ template "am-pattern-1.resource.prefix" . }}-am-2-service:9711"]
     type = "loadbalance"
 
     [[event_handler]]

--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-1-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-1-deployment.yaml
@@ -15,27 +15,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wso2am-pattern-1-am-1-deployment
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-1-deployment
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   strategy:
     rollingUpdate:
-#      maxSurge: 1
-#      maxUnavailable: 0
-    type: Recreate
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
   selector:
     matchLabels:
-      deployment: wso2am-pattern-1-am
-      node: wso2am-pattern-1-am-1
+      deployment: {{ template "am-pattern-1.resource.prefix" . }}-am
+      node: {{ template "am-pattern-1.resource.prefix" . }}-am-1
   template:
     metadata:
       annotations:
         checksum.am.conf: {{ include (print $.Template.BasePath "/am/instance-1/wso2am-pattern-1-am-1-conf.yaml") . | sha256sum }}
         checksum.am.entrypoint: {{ include (print $.Template.BasePath "/am/wso2am-pattern-1-am-conf-entrypoint.yaml") . | sha256sum }}
       labels:
-        deployment: wso2am-pattern-1-am
-        node: wso2am-pattern-1-am-1
+        deployment: {{ template "am-pattern-1.resource.prefix" . }}-am
+        node: {{ template "am-pattern-1.resource.prefix" . }}-am-1
     spec:
       initContainers:
         {{ if .Values.wso2.deployment.dependencies.mysql }}
@@ -45,7 +45,7 @@ spec:
         {{ end }}
         - name: init-am-analytics-worker
           image: busybox:1.31
-          command: ['sh', '-c', 'echo -e "Checking for the availability of WSO2 API Manager Analytics Worker deployment"; while ! nc -z wso2am-pattern-1-analytics-worker-service 7712; do sleep 1; printf "-"; done; echo -e "  >> WSO2 API Manager Analytics Worker has started";']
+          command: ['sh', '-c', 'echo -e "Checking for the availability of WSO2 API Manager Analytics Worker deployment"; while ! nc -z {{ template "am-pattern-1.resource.prefix" . }}-analytics-worker-service 7712; do sleep 1; printf "-"; done; echo -e "  >> WSO2 API Manager Analytics Worker has started";']
       containers:
         - name: wso2am
           {{- if .Values.wso2.deployment.am.dockerRegistry }}
@@ -106,18 +106,18 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           volumeMounts:
-            - name: wso2am-pattern-1-instance-1-carbon-db
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-instance-1-carbon-db
               mountPath: /home/wso2carbon/solr/database
-            - name: wso2am-pattern-1-instance-1-solr
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-instance-1-solr
               mountPath: /home/wso2carbon/solr/indexed-data
-            - name: wso2am-pattern-1-am-volume-claim-executionplans
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-executionplans
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/executionplans
-            - name: wso2am-pattern-1-am-volume-claim-synapse-configs
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-synapse-configs
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/synapse-configs
-            - name: wso2am-pattern-1-am-1-conf
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-1-conf
               mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
               subPath: deployment.toml
-            - name: wso2am-pattern-1-am-conf-entrypoint
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-conf-entrypoint
               mountPath: /home/wso2carbon/docker-entrypoint.sh
               subPath: docker-entrypoint.sh
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
@@ -126,25 +126,25 @@ spec:
         - name: {{ .Values.wso2.deployment.am.imagePullSecrets }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
-        - name: wso2am-pattern-1-wso2-private-registry-creds
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-wso2-private-registry-creds
       {{- end }}
       volumes:
-        - name: wso2am-pattern-1-instance-1-carbon-db
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-instance-1-carbon-db
           persistentVolumeClaim:
-            claimName: wso2am-pattern-1-instance-1-carbon-db
-        - name: wso2am-pattern-1-instance-1-solr
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-instance-1-carbon-db
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-instance-1-solr
           persistentVolumeClaim:
-            claimName: wso2am-pattern-1-instance-1-solr
-        - name: wso2am-pattern-1-am-volume-claim-synapse-configs
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-instance-1-solr
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-synapse-configs
           persistentVolumeClaim:
-            claimName: wso2am-pattern-1-am-volume-claim-synapse-configs
-        - name: wso2am-pattern-1-am-volume-claim-executionplans
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-synapse-configs
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-executionplans
           persistentVolumeClaim:
-            claimName: wso2am-pattern-1-am-volume-claim-executionplans
-        - name: wso2am-pattern-1-am-1-conf
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-executionplans
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-1-conf
           configMap:
-            name: wso2am-pattern-1-am-1-conf
-        - name: wso2am-pattern-1-am-conf-entrypoint
+            name: {{ template "am-pattern-1.resource.prefix" . }}-am-1-conf
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-conf-entrypoint
           configMap:
-            name: wso2am-pattern-1-am-conf-entrypoint
+            name: {{ template "am-pattern-1.resource.prefix" . }}-am-conf-entrypoint
             defaultMode: 0407

--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-1-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-1-deployment.yaml
@@ -21,15 +21,18 @@ spec:
   replicas: 1
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
-    type: RollingUpdate
+#      maxSurge: 1
+#      maxUnavailable: 0
+    type: Recreate
   selector:
     matchLabels:
       deployment: wso2am-pattern-1-am
       node: wso2am-pattern-1-am-1
   template:
     metadata:
+      annotations:
+        checksum.am.conf: {{ include (print $.Template.BasePath "/am/instance-1/wso2am-pattern-1-am-1-conf.yaml") . | sha256sum }}
+        checksum.am.entrypoint: {{ include (print $.Template.BasePath "/am/wso2am-pattern-1-am-conf-entrypoint.yaml") . | sha256sum }}
       labels:
         deployment: wso2am-pattern-1-am
         node: wso2am-pattern-1-am-1

--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-1-service.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-1-service.yaml
@@ -15,13 +15,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: wso2am-pattern-1-am-1-service
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-1-service
   namespace : {{ .Release.Namespace }}
 spec:
   # label keys and values that must match in order to receive traffic for this service
   selector:
-    deployment: wso2am-pattern-1-am
-    node: wso2am-pattern-1-am-1
+    deployment: {{ template "am-pattern-1.resource.prefix" . }}-am
+    node: {{ template "am-pattern-1.resource.prefix" . }}-am-1
   ports:
     # ports that this service should serve on
     - name: binary

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-2-conf.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-2-conf.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: wso2am-pattern-1-am-2-conf
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-2-conf
   namespace : {{ .Release.Namespace }}
   {{ if .Values.wso2.deployment.am.instanceTwo.config }}
 
@@ -84,11 +84,11 @@ data:
 
     [apim.analytics]
     enable = true
-    store_api_url = "https://wso2am-pattern-1-analytics-worker-service:7444"
+    store_api_url = "https://{{ template "am-pattern-1.resource.prefix" . }}-analytics-worker-service:7444"
 
     [[apim.analytics.url_group]]
-    analytics_url =["tcp://wso2am-pattern-1-am-analytics-worker-statefulset-0.wso2am-pattern-1-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7612","tcp://wso2am-pattern-1-am-analytics-worker-statefulset-1.wso2am-pattern-1-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7612"]
-    analytics_auth_url =["ssl://wso2am-pattern-1-am-analytics-worker-statefulset-0.wso2am-pattern-1-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7712","ssl://wso2am-pattern-1-am-analytics-worker-statefulset-1.wso2am-pattern-1-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7712"]
+    analytics_url =["tcp://{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-statefulset-0.{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7612","tcp://{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-statefulset-1.{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7612"]
+    analytics_auth_url =["ssl://{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-statefulset-0.{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7712","ssl://{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-statefulset-1.{{ template "am-pattern-1.resource.prefix" . }}-am-analytics-worker-headless-service.{{ .Release.Namespace }}.svc.cluster.local:7712"]
     type = "failover"
 
     [apim.devportal]
@@ -114,8 +114,8 @@ data:
     type = "loadbalance"
 
     [[apim.throttling.url_group]]
-    traffic_manager_urls = ["tcp://wso2am-pattern-1-am-1-service:9611"]
-    traffic_manager_auth_urls = ["ssl://wso2am-pattern-1-am-1-service:9711"]
+    traffic_manager_urls = ["tcp://{{ template "am-pattern-1.resource.prefix" . }}-am-1-service:9611"]
+    traffic_manager_auth_urls = ["ssl://{{ template "am-pattern-1.resource.prefix" . }}-am-1-service:9711"]
     type = "loadbalance"
 
     [[event_handler]]

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-2-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-2-deployment.yaml
@@ -30,6 +30,9 @@ spec:
       node: wso2am-pattern-1-am-2
   template:
     metadata:
+      annotations:
+        checksum.am.conf: {{ include (print $.Template.BasePath "/am/instance-2/wso2am-pattern-1-am-2-conf.yaml") . | sha256sum }}
+        checksum.am.entrypoint: {{ include (print $.Template.BasePath "/am/wso2am-pattern-1-am-conf-entrypoint.yaml") . | sha256sum }}
       labels:
         deployment: wso2am-pattern-1-am
         node: wso2am-pattern-1-am-2

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-2-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-2-deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wso2am-pattern-1-am-2-deployment
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-2-deployment
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
@@ -26,16 +26,16 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      deployment: wso2am-pattern-1-am
-      node: wso2am-pattern-1-am-2
+      deployment: {{ template "am-pattern-1.resource.prefix" . }}-am
+      node: {{ template "am-pattern-1.resource.prefix" . }}-am-2
   template:
     metadata:
       annotations:
         checksum.am.conf: {{ include (print $.Template.BasePath "/am/instance-2/wso2am-pattern-1-am-2-conf.yaml") . | sha256sum }}
         checksum.am.entrypoint: {{ include (print $.Template.BasePath "/am/wso2am-pattern-1-am-conf-entrypoint.yaml") . | sha256sum }}
       labels:
-        deployment: wso2am-pattern-1-am
-        node: wso2am-pattern-1-am-2
+        deployment: {{ template "am-pattern-1.resource.prefix" . }}-am
+        node: {{ template "am-pattern-1.resource.prefix" . }}-am-2
     spec:
       initContainers:
         {{ if .Values.wso2.deployment.dependencies.mysql }}
@@ -45,7 +45,7 @@ spec:
         {{ end }}
         - name: init-am-analytics-worker
           image: busybox:1.31
-          command: ['sh', '-c', 'echo -e "Checking for the availability of WSO2 API Manager Analytics Worker deployment"; while ! nc -z wso2am-pattern-1-analytics-worker-service 7712; do sleep 1; printf "-"; done; echo -e "  >> WSO2 API Manager Analytics Worker has started";']
+          command: ['sh', '-c', 'echo -e "Checking for the availability of WSO2 API Manager Analytics Worker deployment"; while ! nc -z {{ template "am-pattern-1.resource.prefix" . }}-analytics-worker-service 7712; do sleep 1; printf "-"; done; echo -e "  >> WSO2 API Manager Analytics Worker has started";']
       containers:
         - name: wso2am
           {{- if .Values.wso2.deployment.am.dockerRegistry }}
@@ -106,18 +106,18 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
           volumeMounts:
-            - name: wso2am-pattern-1-instance-2-carbon-db
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-instance-2-carbon-db
               mountPath: /home/wso2carbon/solr/database
-            - name: wso2am-pattern-1-instance-2-solr
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-instance-2-solr
               mountPath: /home/wso2carbon/solr/indexed-data
-            - name: wso2am-pattern-1-am-volume-claim-executionplans
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-executionplans
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/executionplans
-            - name: wso2am-pattern-1-am-volume-claim-synapse-configs
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-synapse-configs
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/synapse-configs
-            - name: wso2am-pattern-1-am-2-conf
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-2-conf
               mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
               subPath: deployment.toml
-            - name: wso2am-pattern-1-am-conf-entrypoint
+            - name: {{ template "am-pattern-1.resource.prefix" . }}-am-conf-entrypoint
               mountPath: /home/wso2carbon/docker-entrypoint.sh
               subPath: docker-entrypoint.sh
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
@@ -126,25 +126,25 @@ spec:
         - name: {{ .Values.wso2.deployment.am.imagePullSecrets }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
-        - name: wso2am-pattern-1-wso2-private-registry-creds
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-wso2-private-registry-creds
       {{- end }}
       volumes:
-        - name: wso2am-pattern-1-instance-2-carbon-db
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-instance-2-carbon-db
           persistentVolumeClaim:
-            claimName: wso2am-pattern-1-instance-2-carbon-db
-        - name: wso2am-pattern-1-instance-2-solr
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-instance-2-carbon-db
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-instance-2-solr
           persistentVolumeClaim:
-            claimName: wso2am-pattern-1-instance-2-solr
-        - name: wso2am-pattern-1-am-volume-claim-executionplans
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-instance-2-solr
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-executionplans
           persistentVolumeClaim:
-            claimName: wso2am-pattern-1-am-volume-claim-executionplans
-        - name: wso2am-pattern-1-am-volume-claim-synapse-configs
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-executionplans
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-synapse-configs
           persistentVolumeClaim:
-            claimName: wso2am-pattern-1-am-volume-claim-synapse-configs
-        - name: wso2am-pattern-1-am-2-conf
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-synapse-configs
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-2-conf
           configMap:
-            name: wso2am-pattern-1-am-2-conf
-        - name: wso2am-pattern-1-am-conf-entrypoint
+            name: {{ template "am-pattern-1.resource.prefix" . }}-am-2-conf
+        - name: {{ template "am-pattern-1.resource.prefix" . }}-am-conf-entrypoint
           configMap:
-            name: wso2am-pattern-1-am-conf-entrypoint
+            name: {{ template "am-pattern-1.resource.prefix" . }}-am-conf-entrypoint
             defaultMode: 0407

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-2-service.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-2-service.yaml
@@ -15,13 +15,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: wso2am-pattern-1-am-2-service
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-2-service
   namespace : {{ .Release.Namespace }}
 spec:
   # label keys and values that must match in order to receive traffic for this service
   selector:
-    deployment: wso2am-pattern-1-am
-    node: wso2am-pattern-1-am-2
+    deployment: {{ template "am-pattern-1.resource.prefix" . }}-am
+    node: {{ template "am-pattern-1.resource.prefix" . }}-am-2
   ports:
     # ports that this service should serve on
     - name: binary

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-conf-entrypoint.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-conf-entrypoint.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: wso2am-pattern-1-am-conf-entrypoint
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-conf-entrypoint
   namespace: {{ .Release.Namespace }}
 data:
   docker-entrypoint.sh: |

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-gateway-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-gateway-ingress.yaml
@@ -15,7 +15,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: wso2am-pattern-1-am-gateway-ingress
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-gateway-ingress
   namespace : {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
@@ -30,5 +30,5 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: wso2am-pattern-1-am-service
+          serviceName: {{ template "am-pattern-1.resource.prefix" . }}-am-service
           servicePort: 8243

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-ingress.yaml
@@ -15,7 +15,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: wso2am-pattern-1-am-ingress
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-ingress
   namespace : {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
@@ -33,5 +33,5 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: wso2am-pattern-1-am-service
+              serviceName: {{ template "am-pattern-1.resource.prefix" . }}-am-service
               servicePort: 9443

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-service.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-service.yaml
@@ -15,12 +15,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: wso2am-pattern-1-am-service
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-service
   namespace : {{ .Release.Namespace }}
 spec:
   # label keys and values that must match in order to receive traffic for this service
   selector:
-    deployment: wso2am-pattern-1-am
+    deployment: {{ template "am-pattern-1.resource.prefix" . }}-am
   ports:
     # ports that this service should serve on
     -

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-volume-claims.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-volume-claims.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: wso2am-pattern-1-am-volume-claim-synapse-configs
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-synapse-configs
   namespace : {{ .Release.Namespace }}
 spec:
   accessModes:
@@ -30,7 +30,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: wso2am-pattern-1-am-volume-claim-executionplans
+  name: {{ template "am-pattern-1.resource.prefix" . }}-am-volume-claim-executionplans
   namespace : {{ .Release.Namespace }}
 spec:
   accessModes:
@@ -45,7 +45,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: wso2am-pattern-1-instance-1-carbon-db
+  name: {{ template "am-pattern-1.resource.prefix" . }}-instance-1-carbon-db
   namespace : {{ .Release.Namespace }}
 spec:
   accessModes:
@@ -60,7 +60,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: wso2am-pattern-1-instance-1-solr
+  name: {{ template "am-pattern-1.resource.prefix" . }}-instance-1-solr
   namespace : {{ .Release.Namespace }}
 spec:
   accessModes:
@@ -75,7 +75,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: wso2am-pattern-1-instance-2-carbon-db
+  name: {{ template "am-pattern-1.resource.prefix" . }}-instance-2-carbon-db
   namespace : {{ .Release.Namespace }}
 spec:
   accessModes:
@@ -90,7 +90,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: wso2am-pattern-1-instance-2-solr
+  name: {{ template "am-pattern-1.resource.prefix" . }}-instance-2-solr
   namespace : {{ .Release.Namespace }}
 spec:
   accessModes:

--- a/advanced/am-pattern-1/templates/wso2am-pattern-1-secrets.yaml
+++ b/advanced/am-pattern-1/templates/wso2am-pattern-1-secrets.yaml
@@ -22,7 +22,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: wso2am-pattern-1-wso2-private-registry-creds
+  name: {{ template "am-pattern-1.resource.prefix" . }}-wso2-private-registry-creds
   namespace: {{ .Release.Namespace }}
 type: kubernetes.io/dockerconfigjson
 data:


### PR DESCRIPTION
## Purpose
> This PR integrates support for automatic rolling update upon ConfigMap changes for deployment pattern 1. Thus, this addresses https://github.com/wso2/kubernetes-apim/issues/379. Further, this PR addresses https://github.com/wso2/kubernetes-apim/issues/388.

## Goals
> Refinements to WSO2 API Management Pattern 1 Helm Resources

## Test environment
> Helm version: 3.1.2
> GKE based Kubernetes Server version: 1.14+, Git Version: `v1.14.10-gke.27`
> WSO2 Private Docker Registry images were utilized