### PR TITLE
[v3.1.x] Set MySQL data source and product Helm Charts to use the same Storage Class

### DIFF
--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       {{ if .Values.wso2.deployment.dependencies.mysql }}
       initContainers:
-        - name: init-apim-analytics-db
+        - name: init-mysql-db
           image: busybox:1.31
           command: ['sh', '-c', 'echo -e "Checking for the availability of MySQL Server deployment"; while ! nc -z "wso2am-mysql-db-service" 3306; do sleep 1; printf "-"; done; echo -e "  >> MySQL Server has started";']
       {{ end }}

--- a/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-3-am-analytics-worker-statefulset.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/worker/wso2am-pattern-3-am-analytics-worker-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       {{ if .Values.wso2.deployment.dependencies.mysql }}
       initContainers:
-        - name: init-apim-analytics-db
+        - name: init-mysql-db
           image: busybox:1.31
           command: ['sh', '-c', 'echo -e "Checking for the availability of MySQL Server deployment"; while ! nc -z "wso2am-mysql-db-service" 3306; do sleep 1; printf "-"; done; echo -e "  >> MySQL Server has started";']
       {{ end }}

--- a/advanced/am-pattern-1/values.yaml
+++ b/advanced/am-pattern-1/values.yaml
@@ -31,7 +31,7 @@ wso2:
       # Must refer to an appropriate Kubernetes Storage Class (https://kubernetes.io/docs/concepts/storage/storage-classes/)
       # "nfs" (default) - Using the official Kubernetes NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner).
       # This provisioner is installed by default, with this Helm Chart (wso2 -> deployment -> dependencies -> nfsServerProvisioner).
-      storageClass: "nfs"
+      storageClass: &storageClass "nfs"
       capacity:
         sharedSynapseConfigs: 50M
         sharedExecutionPlans: 20M
@@ -166,3 +166,8 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-1-svc-account"
+
+mysql-am:
+  mysql:
+    persistence:
+      storageClass: *storageClass

--- a/advanced/am-pattern-2/templates/am/km/wso2am-pattern-2-am-km-deployment.yaml
+++ b/advanced/am-pattern-2/templates/am/km/wso2am-pattern-2-am-km-deployment.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       {{ if .Values.wso2.deployment.dependencies.mysql }}
       initContainers:
-      - name: init-apim-db
+      - name: init-mysql-db
         image: busybox:1.31
         command: ['sh', '-c', 'echo -e "Checking for the availability of DBMS service"; while ! nc -z "wso2am-mysql-db-service" 3306; do sleep 1; printf "-"; done; echo -e "  >> MySQL Server has started";']
       {{- end }}

--- a/advanced/am-pattern-2/values.yaml
+++ b/advanced/am-pattern-2/values.yaml
@@ -31,7 +31,7 @@ wso2:
       # Must refer to an appropriate Kubernetes Storage Class (https://kubernetes.io/docs/concepts/storage/storage-classes/)
       # "nfs" (default) - Using the official Kubernetes NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner).
       # This provisioner is installed by default, with this Helm Chart (wso2 -> deployment -> dependencies -> nfsServerProvisioner).
-      storageClass: "nfs"
+      storageClass: &storageClass "nfs"
       capacity:
         sharedSynapseConfigs: 50M
         sharedExecutionPlans: 20M
@@ -227,3 +227,8 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-2-svc-account"
+
+mysql-am:
+  mysql:
+    persistence:
+      storageClass: *storageClass

--- a/advanced/am-pattern-3/values.yaml
+++ b/advanced/am-pattern-3/values.yaml
@@ -31,7 +31,7 @@ wso2:
       # Must refer to an appropriate Kubernetes Storage Class (https://kubernetes.io/docs/concepts/storage/storage-classes/)
       # "nfs" (default) - Using the official Kubernetes NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner).
       # This provisioner is installed by default, with this Helm Chart (wso2 -> deployment -> dependencies -> nfsServerProvisioner).
-      storageClass: "nfs"
+      storageClass: &storageClass "nfs"
       capacity:
         sharedSynapseConfigs: 50M
         sharedExecutionPlans: 20M
@@ -219,3 +219,8 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-3-svc-account"
+
+mysql-am:
+  mysql:
+    persistence:
+      storageClass: *storageClass

--- a/advanced/mysql-am/values.yaml
+++ b/advanced/mysql-am/values.yaml
@@ -17,6 +17,12 @@ mysql:
   mysqlUser: wso2carbon
   mysqlPassword: wso2carbon
   fullnameOverride: "wso2am-mysql-db-service"
+  persistence:
+    storageClass: "nfs"
+  livenessProbe:
+    initialDelaySeconds: 120
+  readinessProbe:
+    initialDelaySeconds: 120
   configurationFiles:
     mysql.cnf: |-
       [mysqld]
@@ -43,16 +49,6 @@ mysql:
       GRANT ALL ON WSO2AM_PERMISSIONS_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
       GRANT ALL ON WSO2_CLUSTER_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
       GRANT ALL ON WSO2_PERSISTENCE_DB.* TO 'wso2carbon'@'%' IDENTIFIED BY 'wso2carbon';
-
-      USE WSO2AM_STATS_DB;
-
-      CREATE TABLE IF NOT EXISTS AM_USAGE_UPLOADED_FILES (
-      FILE_NAME varchar(255) NOT NULL,
-      FILE_TIMESTAMP TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-      FILE_PROCESSED tinyint(1) DEFAULT 0,
-      FILE_CONTENT MEDIUMBLOB DEFAULT NULL,
-      PRIMARY KEY (FILE_NAME, FILE_TIMESTAMP)
-      );
     mysql_apim.sql: |-
       DROP DATABASE IF EXISTS WSO2AM_DB;
       CREATE DATABASE WSO2AM_DB;


### PR DESCRIPTION
## Purpose
> This PR is to fix $subject. This fixes https://github.com/wso2/kubernetes-apim/issues/417.

## Goals
> Set MySQL data source and product Helm Charts to use the same Storage Class

## Test environment
> Helm version: 3.1.2
> GKE based Kubernetes Server version: `1.14`+, Git Version: `v1.14.10-gke.27`
> WSO2 Private Docker Registry images were utilized