### PR TITLE
[v3.1.x] Set Solr Indexing Persistence To Optional

### DIFF
--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-conf.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-conf.yaml
@@ -275,12 +275,17 @@ data:
     [service_provider]
     sp_name_regex = "^[\\sa-zA-Z0-9._-]*$"
 
+    {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
     [database.local]
     url = "jdbc:h2:/home/wso2carbon/solr/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
 
     [indexing]
     location = "/home/wso2carbon/solr/indexed-data"
-  {{- end }}
+    {{ else }}
+    [database.local]
+    url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+    {{ end }}
+  {{ end }}
 
   jndi2.properties: |-
     connectionfactory.TopicConnectionFactory = amqp://admin:admin@clientid/carbon?brokerlist='tcp://{{ template "am-pattern-1.resource.prefix" . }}-am-2-service:5672'

--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
@@ -108,17 +108,19 @@ spec:
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/executionplans
             - name: wso2am-synapse-configs-storage
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/synapse-configs
+            - name: wso2am-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
+            - name: wso2am-event-publishers-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/eventpublishers
+            {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
             - name: wso2am-local-carbon-database-storage
               mountPath: /home/wso2carbon/solr/database
             - name: wso2am-solr-indexed-data-storage
               mountPath: /home/wso2carbon/solr/indexed-data
-            - name: wso2am-conf
-              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
             - name: wso2am-conf-entrypoint
               mountPath: /home/wso2carbon/docker-entrypoint.sh
               subPath: docker-entrypoint.sh
-            - name: wso2am-event-publishers-conf
-              mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/eventpublishers
+            {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:
@@ -134,19 +136,21 @@ spec:
         - name: wso2am-synapse-configs-storage
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-shared-synapse-configs-volume-claim
-        - name: wso2am-local-carbon-database-storage
-          persistentVolumeClaim:
-            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-1-local-carbon-database-volume-claim
-        - name: wso2am-solr-indexed-data-storage
-          persistentVolumeClaim:
-            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-1-solr-indexed-data-volume-claim
         - name: wso2am-event-publishers-conf
           configMap:
             name: {{ template "am-pattern-1.resource.prefix" . }}-am-event-publishers-conf
         - name: wso2am-conf
           configMap:
             name: {{ template "am-pattern-1.resource.prefix" . }}-am-1-conf
+        {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
+        - name: wso2am-local-carbon-database-storage
+          persistentVolumeClaim:
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-1-local-carbon-database-volume-claim
+        - name: wso2am-solr-indexed-data-storage
+          persistentVolumeClaim:
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-1-solr-indexed-data-volume-claim
         - name: wso2am-conf-entrypoint
           configMap:
             name: {{ template "am-pattern-1.resource.prefix" . }}-am-conf-entrypoint
             defaultMode: 0407
+        {{ end }}

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-conf.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-conf.yaml
@@ -275,12 +275,17 @@ data:
     [service_provider]
     sp_name_regex = "^[\\sa-zA-Z0-9._-]*$"
 
+    {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
     [database.local]
     url = "jdbc:h2:/home/wso2carbon/solr/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
 
     [indexing]
     location = "/home/wso2carbon/solr/indexed-data"
-  {{- end }}
+    {{ else }}
+    [database.local]
+    url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+    {{ end }}
+  {{ end }}
 
   jndi2.properties: |-
     connectionfactory.TopicConnectionFactory = amqp://admin:admin@clientid/carbon?brokerlist='tcp://{{ template "am-pattern-1.resource.prefix" . }}-am-1-service:5672'

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
@@ -108,17 +108,19 @@ spec:
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/executionplans
             - name: wso2am-synapse-configs-storage
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/synapse-configs
+            - name: wso2am-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
+            - name: wso2am-event-publishers-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/eventpublishers
+            {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
             - name: wso2am-local-carbon-database-storage
               mountPath: /home/wso2carbon/solr/database
             - name: wso2am-solr-indexed-data-storage
               mountPath: /home/wso2carbon/solr/indexed-data
-            - name: wso2am-conf
-              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
             - name: wso2am-conf-entrypoint
               mountPath: /home/wso2carbon/docker-entrypoint.sh
               subPath: docker-entrypoint.sh
-            - name: wso2am-event-publishers-conf
-              mountPath: /home/wso2carbon/wso2-config-volume/repository/deployment/server/eventpublishers
+            {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:
@@ -134,19 +136,21 @@ spec:
         - name: wso2am-synapse-configs-storage
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-shared-synapse-configs-volume-claim
-        - name: wso2am-local-carbon-database-storage
-          persistentVolumeClaim:
-            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-2-local-carbon-database-volume-claim
-        - name: wso2am-solr-indexed-data-storage
-          persistentVolumeClaim:
-            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-2-solr-indexed-data-volume-claim
         - name: wso2am-event-publishers-conf
           configMap:
             name: {{ template "am-pattern-1.resource.prefix" . }}-am-event-publishers-conf
         - name: wso2am-conf
           configMap:
             name: {{ template "am-pattern-1.resource.prefix" . }}-am-2-conf
+        {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
+        - name: wso2am-local-carbon-database-storage
+          persistentVolumeClaim:
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-2-local-carbon-database-volume-claim
+        - name: wso2am-solr-indexed-data-storage
+          persistentVolumeClaim:
+            claimName: {{ template "am-pattern-1.resource.prefix" . }}-am-2-solr-indexed-data-volume-claim
         - name: wso2am-conf-entrypoint
           configMap:
             name: {{ template "am-pattern-1.resource.prefix" . }}-am-conf-entrypoint
             defaultMode: 0407
+        {{ end }}

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-conf-entrypoint.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-conf-entrypoint.yaml
@@ -1,3 +1,5 @@
+  {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
+
 # Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,3 +85,5 @@ data:
       # start the server with the specified profile and provided startup arguments
       sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Dprofile=${PROFILE_NAME} "$@"
     fi
+
+  {{ end }}

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-volume-claims.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-volume-claims.yaml
@@ -23,7 +23,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.sharedExecutionPlans }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.capacity.executionPlans }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -38,9 +38,10 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.sharedSynapseConfigs }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.capacity.synapseConfigs }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
+  {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
 ---
 
 apiVersion: v1
@@ -53,7 +54,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.carbonDatabase }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.carbonDatabase }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -68,7 +69,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.solrIndexedData }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -83,7 +84,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.carbonDatabase }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.carbonDatabase }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -98,5 +99,6 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.solrIndexedData }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
+  {{ end }}

--- a/advanced/am-pattern-1/values.yaml
+++ b/advanced/am-pattern-1/values.yaml
@@ -47,7 +47,7 @@ wso2:
       apacheSolrIndexing:
         # Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled
         # By default, this is disabled
-        enabled: true
+        enabled: false
         # Define capacities for persistent runtime artifact directories
         capacity:
           # For persisting the H2 based local Carbon database file
@@ -56,18 +56,20 @@ wso2:
           solrIndexedData: 50M
 
     am:
+      # Hostname for API Manager All In One deployment
+      hostname: "am.wso2.com"
       # API Manager Gateway profile specific configurations
       gateway:
         # Hostname for Gateway profile
         hostname: "gateway.am.wso2.com"
-      # Hostname for API Manager All In One deployment
-      hostname: "am.wso2.com"
 
       # Container image configurations
       # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
       # dockerRegistry: ""
       imageName: "wso2am"
       imageTag: "3.1.0"
+      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+      imagePullPolicy: Always
 
       # Indicates whether the container is running
       livenessProbe:
@@ -81,17 +83,16 @@ wso2:
         initialDelaySeconds: 180
         # How often (in seconds) to perform the probe
         periodSeconds: 10
+
       resources:
         # These are the minimum resource recommendations for running WSO2 API Management product profiles
-        # as per official documentation (https://apim.docs.wso2.com/en/next/SetupAndInstall/InstallationGuide/installation-prerequisites/)
+        # as per official documentation (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
         requests:
           memory: "2Gi"
           cpu: "2000m"
         limits:
           memory: "3Gi"
           cpu: "3000m"
-      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
-      imagePullPolicy: Always
 
       # If the deployment configurations for the WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
       # add the customized configuration file under (wso2 -> deployment -> am -> config -> deployment.toml)
@@ -109,15 +110,18 @@ wso2:
         # dockerRegistry: ""
         imageName: "wso2am-analytics-dashboard"
         imageTag: "3.1.0"
+        # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
         imagePullPolicy: Always
 
-        # Number of Dashboard replicas
+        # Number of deployment replicas
         replicas: 1
+
         # Kubernetes RollingUpdate strategy configurations
         strategy:
           rollingUpdate:
             maxSurge: 1
             maxUnavailable: 0
+
         # Indicates whether the container is running
         livenessProbe:
           # Number of seconds after the container has started before liveness probes are initiated
@@ -130,6 +134,7 @@ wso2:
           initialDelaySeconds: 20
           # How often (in seconds) to perform the probe
           periodSeconds: 10
+
         resources:
           # These are the minimum resource recommendations for running WSO2 Stream Processor based server profiles
           # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites)
@@ -142,6 +147,12 @@ wso2:
           limits:
             memory: "4Gi"
             cpu: "2000m"
+
+        # If the deployment configurations for the Dashboard profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml),
+        # add the customized configuration file under (wso2 -> deployment -> analytics -> dashboard -> config -> deployment.yaml)
+#        config:
+#          deployment.yaml: |-
+#            # deployment configurations for the Dashboard profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml)
 
       worker:
         # Container image configurations
@@ -149,6 +160,7 @@ wso2:
         # dockerRegistry: ""
         imageName: "wso2am-analytics-worker"
         imageTag: "3.1.0"
+        # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
         imagePullPolicy: Always
 
         # Indicates whether the container is running
@@ -163,6 +175,7 @@ wso2:
           initialDelaySeconds: 20
           # How often (in seconds) to perform the probe
           periodSeconds: 10
+
         resources:
           # These are the minimum resource recommendations for running WSO2 Stream Processor based server profiles
           # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites)
@@ -175,6 +188,12 @@ wso2:
           limits:
             memory: "4Gi"
             cpu: "2000m"
+
+        # If the deployment configurations for the Worker profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/worker/deployment.yaml),
+        # add the customized configuration file under (wso2 -> deployment -> analytics -> worker -> config -> deployment.yaml)
+#        config:
+#          deployment.yaml: |-
+#            # deployment configurations for the Worker profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/worker/deployment.yaml)
 
 kubernetes:
   # Name of Kubernetes service account

--- a/advanced/am-pattern-1/values.yaml
+++ b/advanced/am-pattern-1/values.yaml
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 wso2:
-  # WSO2 subscription parameters. If you do not have an active subscription, do not provide values for the parameters.
-  # If you do not possess an active WSO2 subscription already, you can sign up for a WSO2 Free Trial Subscription at (https://wso2.com/free-trial-subscription).
+  # WSO2 Subscription parameters (https://wso2.com/subscription/)
+  # If provided, these parameters will be used to obtain official WSO2 product Docker images available at WSO2 Private Docker Registry (https://docker.wso2.com/)
+  # for this deployment
   subscription:
     username: ""
     password: ""
@@ -26,17 +27,33 @@ wso2:
       # Enable NFS dynamic provisioner for Kubernetes
       nfsServerProvisioner: true
 
+    # Persisted and shared runtime artifacts for API Manager
+    # See official documentation (from https://apim.docs.wso2.com/en/latest/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts/#persistent-runtime-artifacts)
     persistentRuntimeArtifacts:
-      # Persistent storage provider expected to be used for sharing persistent runtime artifacts
-      # Must refer to an appropriate Kubernetes Storage Class (https://kubernetes.io/docs/concepts/storage/storage-classes/)
-      # "nfs" (default) - Using the official Kubernetes NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner).
-      # This provisioner is installed by default, with this Helm Chart (wso2 -> deployment -> dependencies -> nfsServerProvisioner).
-      storageClass: &storageClass "nfs"
-      capacity:
-        sharedSynapseConfigs: 50M
-        sharedExecutionPlans: 20M
-        carbonDatabase: 50M
-        solrIndexedData: 50M
+      # Kubernetes Storage Class to be used to dynamically provision the relevant Persistent Volumes
+      # Only persistent storage solutions supporting ReadWriteMany access mode are applicable (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
+      # Defaults to Kubernetes Storage Class generated using the NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner)
+      storageClass: &storage_class "nfs"
+
+      # Define capacities for persistent runtime artifact directories which are shared between instances of the relevant API Manager profile
+      sharedArtifacts:
+        capacity:
+          # For execution plans shared between the Traffic Manager profile instances
+          executionPlans: 20M
+          # For synapse artifacts of APIs shared between the Gateway profile instances
+          synapseConfigs: 50M
+
+      # Persistent runtime artifacts for Apache Solr-based indexing
+      apacheSolrIndexing:
+        # Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled
+        # By default, this is disabled
+        enabled: true
+        # Define capacities for persistent runtime artifact directories
+        capacity:
+          # For persisting the H2 based local Carbon database file
+          carbonDatabase: 50M
+          # For persisting the indexed data
+          solrIndexedData: 50M
 
     am:
       # API Manager Gateway profile specific configurations
@@ -47,26 +64,26 @@ wso2:
       hostname: "am.wso2.com"
 
       # Container image configurations
-      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
+      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
       # dockerRegistry: ""
       imageName: "wso2am"
       imageTag: "3.1.0"
 
-      # Indicates whether the container is running.
+      # Indicates whether the container is running
       livenessProbe:
-        # Number of seconds after the container has started before liveness probes are initiated.
+        # Number of seconds after the container has started before liveness probes are initiated
         initialDelaySeconds: 180
-        # How often (in seconds) to perform the probe.
+        # How often (in seconds) to perform the probe
         periodSeconds: 10
-      # Indicates whether the container is ready to service requests.
+      # Indicates whether the container is ready to service requests
       readinessProbe:
-        # Number of seconds after the container has started before readiness probes are initiated.
+        # Number of seconds after the container has started before readiness probes are initiated
         initialDelaySeconds: 180
-        # How often (in seconds) to perform the probe.
+        # How often (in seconds) to perform the probe
         periodSeconds: 10
       resources:
         # These are the minimum resource recommendations for running WSO2 API Management product profiles
-        # as per official documentation (https://apim.docs.wso2.com/en/next/SetupAndInstall/InstallationGuide/installation-prerequisites/).
+        # as per official documentation (https://apim.docs.wso2.com/en/next/SetupAndInstall/InstallationGuide/installation-prerequisites/)
         requests:
           memory: "2Gi"
           cpu: "2000m"
@@ -78,87 +95,83 @@ wso2:
 
       # If the deployment configurations for the WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
       # add the customized configuration file under (wso2 -> deployment -> am -> config -> deployment.toml)
-      config: ""
+#      config: ""
 #        deployment.toml: |-
 #          # deployment configurations for the WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
 
     analytics:
       dashboard:
-
         # Hostname for API Manager Analytics Dashboard
         hostname: "analytics.am.wso2.com"
 
         # Container image configurations
-        # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
-        #dockerRegistry: ""
+        # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
+        # dockerRegistry: ""
         imageName: "wso2am-analytics-dashboard"
         imageTag: "3.1.0"
         imagePullPolicy: Always
 
         # Number of Dashboard replicas
         replicas: 1
+        # Kubernetes RollingUpdate strategy configurations
         strategy:
           rollingUpdate:
             maxSurge: 1
             maxUnavailable: 0
-        # Indicates whether the container is running.
+        # Indicates whether the container is running
         livenessProbe:
-          # Number of seconds after the container has started before liveness probes are initiated.
+          # Number of seconds after the container has started before liveness probes are initiated
           initialDelaySeconds: 20
-          # How often (in seconds) to perform the probe.
+          # How often (in seconds) to perform the probe
           periodSeconds: 10
-        # Indicates whether the container is ready to service requests.
+        # Indicates whether the container is ready to service requests
         readinessProbe:
-          # Number of seconds after the container has started before readiness probes are initiated.
+          # Number of seconds after the container has started before readiness probes are initiated
           initialDelaySeconds: 20
-          # How often (in seconds) to perform the probe.
+          # How often (in seconds) to perform the probe
           periodSeconds: 10
         resources:
           # These are the minimum resource recommendations for running WSO2 Stream Processor based server profiles
-          # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites).
+          # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites)
           requests:
             memory: "4Gi"
             cpu: "2000m"
           # Please see the official documentation on WSO2 Stream Processor based Performance Analysis and Resource recommendations
           # (https://docs.wso2.com/display/SP440/Performance+Analysis+Results) and tune the limits according to your needs
-          # where necessary.
+          # where necessary
           limits:
             memory: "4Gi"
             cpu: "2000m"
 
       worker:
         # Container image configurations
-        # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
-        #dockerRegistry: ""
+        # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
+        # dockerRegistry: ""
         imageName: "wso2am-analytics-worker"
         imageTag: "3.1.0"
         imagePullPolicy: Always
 
-        strategy:
-          rollingUpdate:
-            maxSurge: 1
-            maxUnavailable: 0
-        # Indicates whether the container is running.
+        # Indicates whether the container is running
         livenessProbe:
-          # Number of seconds after the container has started before liveness probes are initiated.
+          # Number of seconds after the container has started before liveness probes are initiated
           initialDelaySeconds: 20
-          # How often (in seconds) to perform the probe.
+          # How often (in seconds) to perform the probe
           periodSeconds: 10
-        # Indicates whether the container is ready to service requests.
+        # Indicates whether the container is ready to service requests
         readinessProbe:
-          # Number of seconds after the container has started before readiness probes are initiated.
+          # Number of seconds after the container has started before readiness probes are initiated
           initialDelaySeconds: 20
-          # How often (in seconds) to perform the probe.
+          # How often (in seconds) to perform the probe
           periodSeconds: 10
         resources:
           # These are the minimum resource recommendations for running WSO2 Stream Processor based server profiles
-          # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites).
+          # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites)
           requests:
             memory: "4Gi"
             cpu: "2000m"
           # Please see the official documentation on WSO2 Stream Processor based Performance Analysis and Resource recommendations
           # (https://docs.wso2.com/display/SP440/Performance+Analysis+Results) and tune the limits according to your needs
-          # where necessary.
+          # where necessary
           limits:
             memory: "4Gi"
             cpu: "2000m"
@@ -167,7 +180,8 @@ kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-1-svc-account"
 
+# Override sub chart parameters
 mysql-am:
   mysql:
     persistence:
-      storageClass: *storageClass
+      storageClass: *storage_class

--- a/advanced/am-pattern-2/templates/am/gateway/wso2am-pattern-2-am-gateway-volume-claim.yaml
+++ b/advanced/am-pattern-2/templates/am/gateway/wso2am-pattern-2-am-gateway-volume-claim.yaml
@@ -22,5 +22,5 @@ spec:
   - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.sharedSynapseConfigs }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.capacity.synapseConfigs }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}

--- a/advanced/am-pattern-2/templates/am/pub-devportal-tm/instance-1/wso2am-pattern-2-am-deployment.yaml
+++ b/advanced/am-pattern-2/templates/am/pub-devportal-tm/instance-1/wso2am-pattern-2-am-deployment.yaml
@@ -102,15 +102,17 @@ spec:
           volumeMounts:
             - name: wso2am-executionplans-storage
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/executionplans
+            - name: wso2am-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
+            {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
             - name: wso2am-local-carbon-database-storage
               mountPath: /home/wso2carbon/solr/database
             - name: wso2am-solr-indexed-data-storage
               mountPath: /home/wso2carbon/solr/indexed-data
-            - name: wso2am-conf
-              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
             - name: wso2am-conf-entrypoint
               mountPath: /home/wso2carbon/docker-entrypoint.sh
               subPath: docker-entrypoint.sh
+            {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:
@@ -123,16 +125,18 @@ spec:
         - name: wso2am-executionplans-storage
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-2.resource.prefix" . }}-am-shared-executionplans-volume-claim
+        - name: wso2am-conf
+          configMap:
+            name: {{ template "am-pattern-2.resource.prefix" . }}-am-conf
+        {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
         - name: wso2am-local-carbon-database-storage
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-2.resource.prefix" . }}-am-1-local-carbon-database-volume-claim
         - name: wso2am-solr-indexed-data-storage
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-2.resource.prefix" . }}-am-1-solr-indexed-data-volume-claim
-        - name: wso2am-conf
-          configMap:
-            name: {{ template "am-pattern-2.resource.prefix" . }}-am-conf
         - name: wso2am-conf-entrypoint
           configMap:
             name: {{ template "am-pattern-2.resource.prefix" . }}-am-conf-entrypoint
             defaultMode: 0407
+        {{ end }}

--- a/advanced/am-pattern-2/templates/am/pub-devportal-tm/instance-2/wso2am-pattern-2-am-deployment.yaml
+++ b/advanced/am-pattern-2/templates/am/pub-devportal-tm/instance-2/wso2am-pattern-2-am-deployment.yaml
@@ -102,15 +102,17 @@ spec:
           volumeMounts:
             - name: wso2am-executionplans-storage
               mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/executionplans
+            - name: wso2am-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
+            {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
             - name: wso2am-local-carbon-database-storage
               mountPath: /home/wso2carbon/solr/database
             - name: wso2am-solr-indexed-data-storage
               mountPath: /home/wso2carbon/solr/indexed-data
-            - name: wso2am-conf
-              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
             - name: wso2am-conf-entrypoint
               mountPath: /home/wso2carbon/docker-entrypoint.sh
               subPath: docker-entrypoint.sh
+            {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:
@@ -123,16 +125,18 @@ spec:
         - name: wso2am-executionplans-storage
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-2.resource.prefix" . }}-am-shared-executionplans-volume-claim
+        - name: wso2am-conf
+          configMap:
+            name: {{ template "am-pattern-2.resource.prefix" . }}-am-conf
+        {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
         - name: wso2am-local-carbon-database-storage
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-2.resource.prefix" . }}-am-2-local-carbon-database-volume-claim
         - name: wso2am-solr-indexed-data-storage
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-2.resource.prefix" . }}-am-2-solr-indexed-data-volume-claim
-        - name: wso2am-conf
-          configMap:
-            name: {{ template "am-pattern-2.resource.prefix" . }}-am-conf
         - name: wso2am-conf-entrypoint
           configMap:
             name: {{ template "am-pattern-2.resource.prefix" . }}-am-conf-entrypoint
             defaultMode: 0407
+        {{ end }}

--- a/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-conf-entrypoint.yaml
+++ b/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-conf-entrypoint.yaml
@@ -1,3 +1,5 @@
+  {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
+
 # Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,3 +85,5 @@ data:
       # start the server with the specified profile and provided startup arguments
       sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Dprofile=${PROFILE_NAME} "$@"
     fi
+
+  {{ end }}

--- a/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-conf.yaml
+++ b/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-conf.yaml
@@ -271,9 +271,14 @@ data:
     [service_provider]
     sp_name_regex = "^[\\sa-zA-Z0-9._-]*$"
 
+    {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
     [database.local]
     url = "jdbc:h2:/home/wso2carbon/solr/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
 
     [indexing]
     location = "/home/wso2carbon/solr/indexed-data"
+    {{ else }}
+    [database.local]
+    url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+    {{ end }}
   {{- end }}

--- a/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-volume-claims.yaml
+++ b/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-volume-claims.yaml
@@ -22,8 +22,10 @@ spec:
   - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.sharedExecutionPlans }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.capacity.executionPlans }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
+
+  {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
 
 ---
 
@@ -37,7 +39,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.carbonDatabase }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.carbonDatabase }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -52,7 +54,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.solrIndexedData }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -67,7 +69,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.carbonDatabase }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.carbonDatabase }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -82,5 +84,6 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.solrIndexedData }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
+  {{ end }}

--- a/advanced/am-pattern-2/values.yaml
+++ b/advanced/am-pattern-2/values.yaml
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 wso2:
-  # WSO2 subscription parameters. If you do not have an active subscription, do not provide values for the parameters.
-  # If you do not possess an active WSO2 subscription already, you can sign up for a WSO2 Free Trial Subscription at (https://wso2.com/free-trial-subscription).
+  # WSO2 Subscription parameters (https://wso2.com/subscription/)
+  # If provided, these parameters will be used to obtain official WSO2 product Docker images available at WSO2 Private Docker Registry (https://docker.wso2.com/)
+  # for this deployment
   subscription:
     username: ""
     password: ""
@@ -26,54 +27,196 @@ wso2:
       # Enable NFS dynamic provisioner for Kubernetes
       nfsServerProvisioner: true
 
+    # Persisted and shared runtime artifacts for API Manager
+    # See official documentation (from https://apim.docs.wso2.com/en/latest/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts/#persistent-runtime-artifacts)
     persistentRuntimeArtifacts:
-      # Persistent storage provider expected to be used for sharing persistent runtime artifacts
-      # Must refer to an appropriate Kubernetes Storage Class (https://kubernetes.io/docs/concepts/storage/storage-classes/)
-      # "nfs" (default) - Using the official Kubernetes NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner).
-      # This provisioner is installed by default, with this Helm Chart (wso2 -> deployment -> dependencies -> nfsServerProvisioner).
-      storageClass: &storageClass "nfs"
-      capacity:
-        sharedSynapseConfigs: 50M
-        sharedExecutionPlans: 20M
-        carbonDatabase: 50M
-        solrIndexedData: 50M
+      # Kubernetes Storage Class to be used to dynamically provision the relevant Persistent Volumes
+      # Only persistent storage solutions supporting ReadWriteMany access mode are applicable (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
+      # Defaults to Kubernetes Storage Class generated using the NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner)
+      storageClass: &storage_class "nfs"
+
+      # Define capacities for persistent runtime artifact directories which are shared between instances of the relevant API Manager profile
+      sharedArtifacts:
+        capacity:
+          # For execution plans shared between the Traffic Manager profile instances
+          executionPlans: 20M
+          # For synapse artifacts of APIs shared between the Gateway profile instances
+          synapseConfigs: 50M
+
+      # Persistent runtime artifacts for Apache Solr-based indexing
+      apacheSolrIndexing:
+        # Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled
+        # By default, this is disabled
+        enabled: false
+        # Define capacities for persistent runtime artifact directories
+        capacity:
+          # For persisting the H2 based local Carbon database file
+          carbonDatabase: 50M
+          # For persisting the indexed data
+          solrIndexedData: 50M
+
+    am:
+      # Container image configurations
+      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
+      # dockerRegistry: ""
+      imageName: "wso2am"
+      imageTag: "3.1.0"
+      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+      imagePullPolicy: Always
+
+      resources:
+        # These are the resource recommendations for running WSO2 API Management product profiles with profile optimization
+        # Resource configurations defined here are applicable for Gateway and Key Manager profile deployments, which use profile optimization
+        requests:
+          memory: "1Gi"
+          cpu: "1000m"
+        limits:
+          memory: "2Gi"
+          cpu: "2000m"
+
+      # API Manager's Gateway specific configurations
+      gateway:
+        # Hostname for Gateway profile
+        hostname: "gateway.am.wso2.com"
+
+        # Indicates whether the container is running
+        livenessProbe:
+          # Number of seconds after the container has started before liveness probes are initiated
+          initialDelaySeconds: 60
+          # How often (in seconds) to perform the probe
+          periodSeconds: 10
+        # Indicates whether the container is ready to service requests
+        readinessProbe:
+          # Number of seconds after the container has started before readiness probes are initiated
+          initialDelaySeconds: 60
+          # How often (in seconds) to perform the probe
+          periodSeconds: 10
+
+        # Number of deployment replicas
+        replicas: 2
+
+        # Kubernetes RollingUpdate strategy configurations
+        strategy:
+          rollingUpdate:
+            # The maximum number of pods that can be scheduled above the desired number of pods
+            maxSurge: 2
+            # The maximum number of pods that can be unavailable during the update
+            maxUnavailable: 0
+
+        # If the deployment configurations for the Gateway profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
+        # add the customized configuration file under (wso2 -> deployment -> am -> gateway -> config -> deployment.toml)
+#        config:
+#          deployment.toml: |-
+#            # deployment configurations for the Gateway profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
+
+      # API Manager's Key Manager specific configurations
+      km:
+        livenessProbe:
+          # Number of seconds after the container has started before liveness probes are initiated
+          initialDelaySeconds: 60
+          # How often (in seconds) to perform the probe
+          periodSeconds: 10
+          # Indicates whether the container is ready to service requests
+        readinessProbe:
+          # Number of seconds after the container has started before readiness probes are initiated
+          initialDelaySeconds: 60
+          # How often (in seconds) to perform the probe
+          periodSeconds: 10
+
+        # Number of deployment replicas
+        replicas: 2
+
+        # Kubernetes RollingUpdate strategy configurations
+        strategy:
+          rollingUpdate:
+            # The maximum number of pods that can be scheduled above the desired number of pods
+            maxSurge: 2
+            # The maximum number of pods that can be unavailable during the update
+            maxUnavailable: 0
+
+        # If the deployment configurations for the Key Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
+        # add the customized configuration file under (wso2 -> deployment -> am -> km -> config -> deployment.toml)
+#        config:
+#          deployment.toml: |-
+#            # deployment configurations for the Key Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
+
+      pubDevPortalTM:
+        # Hostname for Publisher-DevPortal deployment
+        hostname: "am.wso2.com"
+
+        # Indicates whether the container is running
+        livenessProbe:
+          # Number of seconds after the container has started before liveness probes are initiated
+          initialDelaySeconds: 180
+          # How often (in seconds) to perform the probe
+          periodSeconds: 10
+          # Indicates whether the container is ready to service requests
+        readinessProbe:
+          # Number of seconds after the container has started before readiness probes are initiated
+          initialDelaySeconds: 180
+          # How often (in seconds) to perform the probe
+          periodSeconds: 10
+
+        # If the deployment configurations for the Publisher-Store-TM of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
+        # add the customized configuration file under (wso2 -> deployment -> am -> pubDevPortalTM -> instanceTwo -> config -> deployment.toml)
+#        config: ""
+#          deployment.toml: |-
+#            # deployment configurations for All-In-One WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
+
+        resources:
+          # These are the resource recommendations for running WSO2 API Management All-In-One deployment
+          # as per official documentation (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
+          requests:
+            memory: "2Gi"
+            cpu: "2000m"
+          limits:
+            memory: "3Gi"
+            cpu: "3000m"
 
     analytics:
       dashboard:
         # Hostname for API Manager Analytics Dashboard
         hostname: "analytics.am.wso2.com"
-        # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
-        #dockerRegistry: ""
+
+        # Container image configurations
+        # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
+        # dockerRegistry: ""
         imageName: "wso2am-analytics-dashboard"
         imageTag: "3.1.0"
         # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
         imagePullPolicy: Always
+
         # Number of deployment replicas
         replicas: 1
+
+        # Kubernetes RollingUpdate strategy configurations
         strategy:
           rollingUpdate:
-            # The maximum number of pods that can be scheduled above the desired number of pods.
+            # The maximum number of pods that can be scheduled above the desired number of pods
             maxSurge: 1
-            # The maximum number of pods that can be unavailable during the update.
+            # The maximum number of pods that can be unavailable during the update
             maxUnavailable: 0
-        # Indicates whether the container is running.
+
+        # Indicates whether the container is running
         livenessProbe:
-          # Number of seconds after the container has started before liveness probes are initiated.
+          # Number of seconds after the container has started before liveness probes are initiated
           initialDelaySeconds: 20
-          # How often (in seconds) to perform the probe.
+          # How often (in seconds) to perform the probe
           periodSeconds: 10
-        # Indicates whether the container is ready to service requests.
+        # Indicates whether the container is ready to service requests
         readinessProbe:
-          # Number of seconds after the container has started before readiness probes are initiated.
+          # Number of seconds after the container has started before readiness probes are initiated
           initialDelaySeconds: 20
-          # How often (in seconds) to perform the probe.
+          # How often (in seconds) to perform the probe
           periodSeconds: 10
+
         # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
-#        # If the deployment configurations for the Dashboard profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml),
-#        # add the customized configuration file under (wso2 -> deployment -> analytics -> dashboard -> config -> deployment.yaml)
+        # If the deployment configurations for the Dashboard profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml),
+        # add the customized configuration file under (wso2 -> deployment -> analytics -> dashboard -> config -> deployment.yaml)
 #        config:
 #          deployment.yaml: |-
 #            # deployment configurations for the Dashboard profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml)
+
         resources:
           # These are the resource recommendations for running WSO2 Stream Processor based server profiles
           # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites).
@@ -88,12 +231,14 @@ wso2:
             cpu: "2000m"
 
       worker:
+        # Container image configurations
         # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
-        #dockerRegistry: ""
+        # dockerRegistry: ""
         imageName: "wso2am-analytics-worker"
         imageTag: "3.1.0"
         # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
         imagePullPolicy: Always
+
         # Indicates whether the container is running.
         livenessProbe:
           # Number of seconds after the container has started before liveness probes are initiated.
@@ -106,11 +251,13 @@ wso2:
           initialDelaySeconds: 20
           # How often (in seconds) to perform the probe.
           periodSeconds: 10
-#        # If the deployment configurations for the Worker profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/worker/deployment.yaml),
-#        # add the customized configuration file under (wso2 -> deployment -> analytics -> worker -> config -> deployment.yaml)
+
+        # If the deployment configurations for the Worker profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/worker/deployment.yaml),
+        # add the customized configuration file under (wso2 -> deployment -> analytics -> worker -> config -> deployment.yaml)
 #        config:
 #          deployment.yaml: |-
 #            # deployment configurations for the Worker profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/worker/deployment.yaml)
+
         resources:
           # These are the resource recommendations for running WSO2 Stream Processor based server profiles
           # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites).
@@ -124,111 +271,12 @@ wso2:
             memory: "4Gi"
             cpu: "2000m"
 
-    am:
-      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
-      #dockerRegistry: ""
-      imageName: "wso2am"
-      imageTag: "3.1.0"
-      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
-      imagePullPolicy: Always
-      resources:
-        # These are the resource recommendations for running WSO2 API Management product profiles with profile optimization.
-        requests:
-          memory: "1Gi"
-          cpu: "1000m"
-        limits:
-          memory: "2Gi"
-          cpu: "2000m"
-      # API Manager's Gateway specific configurations
-      gateway:
-        # Hostname for Gateway profile
-        hostname: "gateway.am.wso2.com"
-        livenessProbe:
-          # Number of seconds after the container has started before liveness probes are initiated.
-          initialDelaySeconds: 60
-          # How often (in seconds) to perform the probe.
-          periodSeconds: 10
-          # Indicates whether the container is ready to service requests.
-        readinessProbe:
-          # Number of seconds after the container has started before readiness probes are initiated.
-          initialDelaySeconds: 60
-          # How often (in seconds) to perform the probe.
-          periodSeconds: 10
-        # Number of deployment replicas
-        replicas: 2
-        strategy:
-          rollingUpdate:
-            # The maximum number of pods that can be scheduled above the desired number of pods.
-            maxSurge: 2
-            # The maximum number of pods that can be unavailable during the update.
-            maxUnavailable: 0
-#        # If the deployment configurations for the Gateway profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
-#        # add the customized configuration file under (wso2 -> deployment -> am -> gateway -> config -> deployment.toml)
-#        config:
-#          deployment.toml: |-
-#            # deployment configurations for the Gateway profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
-
-      # API Manager's Key Manager specific configurations
-      km:
-        livenessProbe:
-          # Number of seconds after the container has started before liveness probes are initiated.
-          initialDelaySeconds: 60
-          # How often (in seconds) to perform the probe.
-          periodSeconds: 10
-          # Indicates whether the container is ready to service requests.
-        readinessProbe:
-          # Number of seconds after the container has started before readiness probes are initiated.
-          initialDelaySeconds: 60
-          # How often (in seconds) to perform the probe.
-          periodSeconds: 10
-        # Number of deployment replicas
-        replicas: 2
-        strategy:
-          rollingUpdate:
-            # The maximum number of pods that can be scheduled above the desired number of pods.
-            maxSurge: 2
-            # The maximum number of pods that can be unavailable during the update.
-            maxUnavailable: 0
-#        # If the deployment configurations for the Key Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
-#        # add the customized configuration file under (wso2 -> deployment -> am -> km -> config -> deployment.toml)
-#        config:
-#          deployment.toml: |-
-#            # deployment configurations for the Key Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
-
-      pubDevPortalTM:
-        # Hostname for Publisher-DevPortal deployment
-        hostname: "am.wso2.com"
-        livenessProbe:
-          # Number of seconds after the container has started before liveness probes are initiated.
-          initialDelaySeconds: 180
-          # How often (in seconds) to perform the probe.
-          periodSeconds: 10
-          # Indicates whether the container is ready to service requests.
-        readinessProbe:
-          # Number of seconds after the container has started before readiness probes are initiated.
-          initialDelaySeconds: 180
-          # How often (in seconds) to perform the probe.
-          periodSeconds: 10
-        # If the deployment configurations for the Publisher-Store-TM of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
-        # add the customized configuration file under (wso2 -> deployment -> am -> pubDevPortalTM -> instanceTwo -> config -> deployment.toml)
-#        config: ""
-#          deployment.toml: |-
-#            # deployment configurations for the Key Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
-        resources:
-          # These are the resource recommendations for running WSO2 API Management All-In-One deployment
-          # as per official documentation (https://apim.docs.wso2.com/en/next/SetupAndInstall/InstallationGuide/installation-prerequisites/).
-          requests:
-            memory: "2Gi"
-            cpu: "2000m"
-          limits:
-            memory: "3Gi"
-            cpu: "3000m"
-
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-2-svc-account"
 
+# Override sub chart parameters
 mysql-am:
   mysql:
     persistence:
-      storageClass: *storageClass
+      storageClass: *storage_class

--- a/advanced/am-pattern-3/templates/am/devportal/instance-1/wso2am-pattern-3-am-devportal-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/devportal/instance-1/wso2am-pattern-3-am-devportal-deployment.yaml
@@ -97,16 +97,17 @@ spec:
           securityContext:
             runAsUser: 802
           volumeMounts:
+          - name: wso2am-devportal-conf
+            mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
+          {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
           - name: wso2am-devportal-local-carbon-database-storage
             mountPath: /home/wso2carbon/solr/database
           - name: wso2am-devportal-indexed-data-volume
             mountPath: /home/wso2carbon/solr/indexed-data
-          - name: wso2am-devportal-conf
-            mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
-            subPath: deployment.toml
           - name: wso2am-devportal-conf-entrypoint
             mountPath: /home/wso2carbon/docker-entrypoint.sh
             subPath: docker-entrypoint.sh
+          {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:
@@ -119,6 +120,7 @@ spec:
         - name: wso2am-devportal-conf
           configMap:
             name: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-conf
+        {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
         - name: wso2am-devportal-conf-entrypoint
           configMap:
             name: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-conf-entrypoint
@@ -129,3 +131,4 @@ spec:
         - name: wso2am-devportal-indexed-data-volume
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-1-solr-indexed-data-volume-claim
+        {{ end }}

--- a/advanced/am-pattern-3/templates/am/devportal/instance-2/wso2am-pattern-3-am-devportal-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/devportal/instance-2/wso2am-pattern-3-am-devportal-deployment.yaml
@@ -97,16 +97,17 @@ spec:
           securityContext:
             runAsUser: 802
           volumeMounts:
+            - name: wso2am-devportal-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
+            {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
             - name: wso2am-devportal-local-carbon-database-storage
               mountPath: /home/wso2carbon/solr/database
             - name: wso2am-devportal-indexed-data-volume
               mountPath: /home/wso2carbon/solr/indexed-data
-            - name: wso2am-devportal-conf
-              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
-              subPath: deployment.toml
             - name: wso2am-devportal-conf-entrypoint
               mountPath: /home/wso2carbon/docker-entrypoint.sh
               subPath: docker-entrypoint.sh
+            {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:
@@ -119,6 +120,7 @@ spec:
         - name: wso2am-devportal-conf
           configMap:
             name: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-conf
+        {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
         - name: wso2am-devportal-conf-entrypoint
           configMap:
             name: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-conf-entrypoint
@@ -129,3 +131,4 @@ spec:
         - name: wso2am-devportal-indexed-data-volume
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-2-solr-indexed-data-volume-claim
+        {{ end }}

--- a/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-conf-entrypoint.yaml
+++ b/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-conf-entrypoint.yaml
@@ -1,3 +1,5 @@
+  {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
+
 # Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,3 +85,5 @@ data:
       # start the server with the specified profile and provided startup arguments
       sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Dprofile=${PROFILE_NAME} "$@"
     fi
+
+  {{ end }}

--- a/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-conf.yaml
+++ b/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-conf.yaml
@@ -142,9 +142,14 @@ data:
     [transport.https.properties]
     proxyPort = 443
 
+    {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
     [database.local]
     url = "jdbc:h2:/home/wso2carbon/solr/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
 
     [indexing]
     location = "/home/wso2carbon/solr/indexed-data"
+    {{ else }}
+    [database.local]
+    url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+    {{ end }}
   {{- end }}

--- a/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-volume-claims.yaml
+++ b/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-volume-claims.yaml
@@ -1,3 +1,5 @@
+  {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
+
 # Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,36 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ template "am-pattern-3.resource.prefix" . }}-devportal-1-indexed-data-volume-claim
-  namespace : {{ .Release.Namespace }}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
-  storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
-
----
-
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ template "am-pattern-3.resource.prefix" . }}-devportal-2-indexed-data-volume-claim
-  namespace : {{ .Release.Namespace }}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
-  storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
-  
----
   
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -52,7 +24,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.carbonDatabase }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.carbonDatabase }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -67,7 +39,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.solrIndexedData }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -82,7 +54,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.carbonDatabase }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.carbonDatabase }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -97,5 +69,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.solrIndexedData }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
+
+  {{ end }}

--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
@@ -109,8 +109,7 @@ spec:
         - name: wso2am-gateway-storage-volume
           mountPath: /home/wso2carbon/wso2am-3.1.0/repository/deployment/server/synapse-configs
         - name: wso2am-gateway-conf
-          mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
-          subPath: deployment.toml
+          mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:

--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-volume-claim.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-volume-claim.yaml
@@ -22,5 +22,5 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.sharedSynapseConfigs }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.capacity.synapseConfigs }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}

--- a/advanced/am-pattern-3/templates/am/km/wso2am-pattern-3-am-km-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/km/wso2am-pattern-3-am-km-deployment.yaml
@@ -96,8 +96,7 @@ spec:
             protocol: "TCP"
         volumeMounts:
         - name: wso2am-km-conf
-          mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
-          subPath: deployment.toml
+          mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:

--- a/advanced/am-pattern-3/templates/am/publisher/instance-1/wso2am-pattern-3-am-publisher-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/publisher/instance-1/wso2am-pattern-3-am-publisher-deployment.yaml
@@ -97,16 +97,17 @@ spec:
           securityContext:
             runAsUser: 802
           volumeMounts:
+          - name: wso2am-publisher-conf
+            mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
+          {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
           - name: wso2am-publisher-local-carbon-database-storage
             mountPath: /home/wso2carbon/solr/database
           - name: wso2am-publisher-indexed-data-volume
             mountPath: /home/wso2carbon/solr/indexed-data
-          - name: wso2am-publisher-conf
-            mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
-            subPath: deployment.toml
           - name: wso2am-publisher-conf-entrypoint
             mountPath: /home/wso2carbon/docker-entrypoint.sh
             subPath: docker-entrypoint.sh
+          {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:
@@ -119,6 +120,7 @@ spec:
         - name: wso2am-publisher-conf
           configMap:
             name: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-conf
+        {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
         - name: wso2am-publisher-conf-entrypoint
           configMap:
             name: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-conf-entrypoint
@@ -129,3 +131,4 @@ spec:
         - name: wso2am-publisher-indexed-data-volume
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-1-solr-indexed-data-volume-claim
+        {{ end }}

--- a/advanced/am-pattern-3/templates/am/publisher/instance-2/wso2am-pattern-3-am-publisher-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/publisher/instance-2/wso2am-pattern-3-am-publisher-deployment.yaml
@@ -97,16 +97,17 @@ spec:
           securityContext:
             runAsUser: 802
           volumeMounts:
+          - name: wso2am-publisher-conf
+            mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
+          {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
           - name: wso2am-publisher-local-carbon-database-storage
             mountPath: /home/wso2carbon/solr/database
           - name: wso2am-publisher-indexed-data-volume
             mountPath: /home/wso2carbon/solr/indexed-data
-          - name: wso2am-publisher-conf
-            mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
-            subPath: deployment.toml
           - name: wso2am-publisher-conf-entrypoint
             mountPath: /home/wso2carbon/docker-entrypoint.sh
             subPath: docker-entrypoint.sh
+          {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}
       imagePullSecrets:
@@ -119,6 +120,7 @@ spec:
         - name: wso2am-publisher-conf
           configMap:
             name: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-conf
+        {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
         - name: wso2am-publisher-conf-entrypoint
           configMap:
             name: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-conf-entrypoint
@@ -129,3 +131,4 @@ spec:
         - name: wso2am-publisher-indexed-data-volume
           persistentVolumeClaim:
             claimName: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-2-solr-indexed-data-volume-claim
+        {{ end }}

--- a/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-conf-entrypoint.yaml
+++ b/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-conf-entrypoint.yaml
@@ -1,3 +1,5 @@
+  {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
+
 # Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,3 +85,5 @@ data:
       # start the server with the specified profile and provided startup arguments
       sh ${WSO2_SERVER_HOME}/bin/wso2server.sh -Dprofile=${PROFILE_NAME} "$@"
     fi
+
+  {{ end }}

--- a/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-conf.yaml
+++ b/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-conf.yaml
@@ -131,10 +131,15 @@ data:
     [transport.https.properties]
     proxyPort = 443
 
+    {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
     [database.local]
     url = "jdbc:h2:/home/wso2carbon/solr/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
 
     [indexing]
     location = "/home/wso2carbon/solr/indexed-data"
+    {{ else }}
+    [database.local]
+    url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+    {{ end }}
   {{- end }}
 

--- a/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-volume-claims.yaml
+++ b/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-volume-claims.yaml
@@ -1,3 +1,5 @@
+  {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.enabled }}
+
 # Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,35 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ template "am-pattern-3.resource.prefix" . }}-publisher-1-indexed-data-volume-claim
-  namespace : {{ .Release.Namespace }}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
-  storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
-
----
-
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ template "am-pattern-3.resource.prefix" . }}-publisher-2-indexed-data-volume-claim
-  namespace : {{ .Release.Namespace }}
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
-  storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
-
----
 
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -52,7 +25,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.carbonDatabase }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.carbonDatabase }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -67,7 +40,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.solrIndexedData }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -82,7 +55,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.carbonDatabase }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.carbonDatabase }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -97,5 +70,7 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.solrIndexedData }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.apacheSolrIndexing.capacity.solrIndexedData }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
+
+  {{ end }}

--- a/advanced/am-pattern-3/templates/am/tm/wso2am-pattern-3-am-tm-volume-claim.yaml
+++ b/advanced/am-pattern-3/templates/am/tm/wso2am-pattern-3-am-tm-volume-claim.yaml
@@ -22,5 +22,5 @@ spec:
   - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.capacity.sharedExecutionPlans }}
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.capacity.executionPlans }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}

--- a/advanced/am-pattern-3/values.yaml
+++ b/advanced/am-pattern-3/values.yaml
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 wso2:
-  # WSO2 subscription parameters. If you do not have an active subscription, do not provide values for the parameters.
-  # If you do not possess an active WSO2 subscription already, you can sign up for a WSO2 Free Trial Subscription at (https://wso2.com/free-trial-subscription).
+  # WSO2 Subscription parameters (https://wso2.com/subscription/)
+  # If provided, these parameters will be used to obtain official WSO2 product Docker images available at WSO2 Private Docker Registry (https://docker.wso2.com/)
+  # for this deployment
   subscription:
     username: ""
     password: ""
@@ -26,24 +27,145 @@ wso2:
       # Enable NFS dynamic provisioner for Kubernetes
       nfsServerProvisioner: true
 
+    # Persisted and shared runtime artifacts for API Manager
+    # See official documentation (from https://apim.docs.wso2.com/en/latest/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts/#persistent-runtime-artifacts)
     persistentRuntimeArtifacts:
-      # Persistent storage provider expected to be used for sharing persistent runtime artifacts
-      # Must refer to an appropriate Kubernetes Storage Class (https://kubernetes.io/docs/concepts/storage/storage-classes/)
-      # "nfs" (default) - Using the official Kubernetes NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner).
-      # This provisioner is installed by default, with this Helm Chart (wso2 -> deployment -> dependencies -> nfsServerProvisioner).
-      storageClass: &storageClass "nfs"
-      capacity:
-        sharedSynapseConfigs: 50M
-        sharedExecutionPlans: 20M
-        carbonDatabase: 50M
-        solrIndexedData: 50M
+      # Kubernetes Storage Class to be used to dynamically provision the relevant Persistent Volumes
+      # Only persistent storage solutions supporting ReadWriteMany access mode are applicable (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
+      # Defaults to Kubernetes Storage Class generated using the NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner)
+      storageClass: &storage_class "nfs"
+
+      # Define capacities for persistent runtime artifact directories which are shared between instances of the relevant API Manager profile
+      sharedArtifacts:
+        capacity:
+          # For execution plans shared between the Traffic Manager profile instances
+          executionPlans: 20M
+          # For synapse artifacts of APIs shared between the Gateway profile instances
+          synapseConfigs: 50M
+
+      # Persistent runtime artifacts for Apache Solr-based indexing
+      apacheSolrIndexing:
+        # Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled
+        # By default, this is disabled
+        enabled: false
+        # Define capacities for persistent runtime artifact directories
+        capacity:
+          # For persisting the H2 based local Carbon database file
+          carbonDatabase: 50M
+          # For persisting the indexed data
+          solrIndexedData: 50M
+
+    am:
+      # Container image configurations
+      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
+      # dockerRegistry: ""
+      imageName: "wso2am"
+      imageTag: "3.1.0"
+      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+      imagePullPolicy: Always
+
+      resources:
+        # These are the resource recommendations for running WSO2 API Management product profiles with profile optimization
+        # Resource configurations defined here are applicable for all API Manager product profiles of this deployment
+        requests:
+          memory: "1Gi"
+          cpu: "1000m"
+        limits:
+          memory: "2Gi"
+          cpu: "2000m"
+
+      # Indicates whether the container is running
+      livenessProbe:
+        # Number of seconds after the container has started before liveness probes are initiated
+        initialDelaySeconds: 60
+        # How often (in seconds) to perform the probe
+        periodSeconds: 10
+        # Indicates whether the container is ready to service requests
+      readinessProbe:
+        # Number of seconds after the container has started before readiness probes are initiated
+        initialDelaySeconds: 60
+        # How often (in seconds) to perform the probe
+        periodSeconds: 10
+
+      # API Manager's Gateway specific configurations
+      gateway:
+        # Hostname for Gateway profile
+        hostname: "gateway.am.wso2.com"
+
+        # Number of deployment replicas
+        replicas: 2
+
+        # Kubernetes RollingUpdate strategy configurations
+        strategy:
+          rollingUpdate:
+            # The maximum number of pods that can be scheduled above the desired number of pods
+            maxSurge: 2
+            # The maximum number of pods that can be unavailable during the update
+            maxUnavailable: 0
+
+        # If the deployment configurations for the Gateway profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
+        # add the customized configuration file under (wso2 -> deployment -> am -> gateway -> config -> deployment.toml)
+#        config:
+#          deployment.toml: |-
+#            # deployment configurations for the Gateway profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
+
+      # API Manager's Key Manager specific configurations
+      km:
+        # Number of deployment replicas
+        replicas: 2
+
+        # Kubernetes RollingUpdate strategy configurations
+        strategy:
+          rollingUpdate:
+            # The maximum number of pods that can be scheduled above the desired number of pods
+            maxSurge: 2
+            # The maximum number of pods that can be unavailable during the update
+            maxUnavailable: 0
+
+        # If the deployment configurations for the Key Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
+        # add the customized configuration file under (wso2 -> deployment -> am -> km -> config -> deployment.toml)
+#        config:
+#          deployment.toml: |-
+#            # deployment configurations for the Key Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
+
+      # API Manager's Publisher specific configurations
+      publisher:
+        # Hostname for Publisher profile
+        hostname: "publisher.am.wso2.com"
+
+        # If the deployment configurations for the Publisher profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
+        # add the customized configuration file under (wso2 -> deployment -> am -> publisher -> config -> deployment.toml)
+#        config:
+#          deployment.toml: |-
+#            # deployment configurations for the Publisher profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
+
+      # API Manager's DevPortal specific configurations
+      devportal:
+        # Hostname for DevPortal profile
+        hostname: "devportal.am.wso2.com"
+
+        # If the deployment configurations for the DevPortal profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
+        # add the customized configuration file under (wso2 -> deployment -> am -> devportal -> config -> deployment.toml)
+#        config:
+#          deployment.toml: |-
+#            # deployment configurations for the DevPortal profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
+
+      # API Manager's Traffic Manager specific configurations
+      tm:
+        # If the deployment configurations for the Traffic Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
+        # add the customized configuration file under (wso2 -> deployment -> am -> tm -> instanceOne -> config -> deployment.toml)
+        config: ""
+#          deployment.toml: |-
+#            # deployment configurations for the Traffic Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
 
     analytics:
       dashboard:
         # Hostname for API Manager Analytics Dashboard
         hostname: "analytics.am.wso2.com"
+
+        # Container image configurations
         # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
-#        dockerRegistry: ""
+        # dockerRegistry: ""
         imageName: "wso2am-analytics-dashboard"
         imageTag: "3.1.0"
         # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
@@ -51,12 +173,15 @@ wso2:
 
         # Number of deployment replicas
         replicas: 1
+
+        # Kubernetes RollingUpdate strategy configurations
         strategy:
           rollingUpdate:
             # The maximum number of pods that can be scheduled above the desired number of pods.
             maxSurge: 1
             # The maximum number of pods that can be unavailable during the update.
             maxUnavailable: 0
+
         # Indicates whether the container is running.
         livenessProbe:
           # Number of seconds after the container has started before liveness probes are initiated.
@@ -69,11 +194,13 @@ wso2:
           initialDelaySeconds: 20
           # How often (in seconds) to perform the probe.
           periodSeconds: 10
+
 #        # If the deployment configurations for the Dashboard profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml),
 #        # add the customized configuration file under (wso2 -> deployment -> analytics -> dashboard -> config -> deployment.yaml)
 #        config:
 #          deployment.yaml: |-
 #            # deployment configurations for the Dashboard profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml)
+
         resources:
           # These are the minimum resource recommendations for running WSO2 Stream Processor based server profiles
           # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites).
@@ -88,12 +215,14 @@ wso2:
             cpu: "2000m"
 
       worker:
+        # Container image configurations
         # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
-#        dockerRegistry: ""
+        # dockerRegistry: ""
         imageName: "wso2am-analytics-worker"
         imageTag: "3.1.0"
         # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
         imagePullPolicy: Always
+
         # Indicates whether the container is running.
         livenessProbe:
           # Number of seconds after the container has started before liveness probes are initiated.
@@ -106,11 +235,13 @@ wso2:
           initialDelaySeconds: 20
           # How often (in seconds) to perform the probe.
           periodSeconds: 10
-#        # If the deployment configurations for the Worker profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/worker/deployment.yaml),
-#        # add the customized configuration file under (wso2 -> deployment -> analytics -> worker -> config -> deployment.yaml)
+
+        # If the deployment configurations for the Worker profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/worker/deployment.yaml),
+        # add the customized configuration file under (wso2 -> deployment -> analytics -> worker -> config -> deployment.yaml)
 #        config:
 #          deployment.yaml: |-
 #            # deployment configurations for the Worker profile of WSO2 API Manager Analytics v3.1.0 (<WSO2AM_ANALYTICS>/conf/worker/deployment.yaml)
+
         resources:
           # These are the minimum resource recommendations for running WSO2 Stream Processor based server profiles
           # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites).
@@ -124,103 +255,12 @@ wso2:
             memory: "4Gi"
             cpu: "2000m"
 
-    am:
-      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
-#      dockerRegistry: ""
-      imageName: "wso2am"
-      imageTag: "3.1.0"
-      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
-      imagePullPolicy: Always
-
-      # API Manager's Gateway specific configurations
-      gateway:
-        # Hostname for Gateway profile
-        hostname: "gateway.am.wso2.com"
-        # Number of deployment replicas
-        replicas: 2
-        strategy:
-          rollingUpdate:
-            # The maximum number of pods that can be scheduled above the desired number of pods.
-            maxSurge: 2
-            # The maximum number of pods that can be unavailable during the update.
-            maxUnavailable: 0
-#        # If the deployment configurations for the Gateway profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
-#        # add the customized configuration file under (wso2 -> deployment -> am -> gateway -> config -> deployment.toml)
-#        config:
-#          deployment.toml: |-
-#            # deployment configurations for the Gateway profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
-
-      # API Manager's Key Manager specific configurations
-      km:
-        # Number of deployment replicas
-        replicas: 2
-        strategy:
-          rollingUpdate:
-            # The maximum number of pods that can be scheduled above the desired number of pods.
-            maxSurge: 2
-            # The maximum number of pods that can be unavailable during the update.
-            maxUnavailable: 0
-#        # If the deployment configurations for the Key Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
-#        # add the customized configuration file under (wso2 -> deployment -> am -> km -> config -> deployment.toml)
-#        config:
-#          deployment.toml: |-
-#            # deployment configurations for the Key Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
-
-      # API Manager's Publisher specific configurations
-      publisher:
-        # Hostname for Publisher profile
-        hostname: "publisher.am.wso2.com"
-#        # If the deployment configurations for the Publisher profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
-#        # add the customized configuration file under (wso2 -> deployment -> am -> km -> config -> deployment.toml)
-#        config:
-#          deployment.toml: |-
-#            # deployment configurations for the Publisher profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
-
-      # API Manager's DevPortal specific configurations
-      devportal:
-        # Hostname for DevPortal profile
-        hostname: "devportal.am.wso2.com"
-#        # If the deployment configurations for the DevPortal profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
-#        # add the customized configuration file under (wso2 -> deployment -> am -> km -> config -> deployment.toml)
-#        config:
-#          deployment.toml: |-
-#            # deployment configurations for the DevPortal profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
-
-      # API Manager's Traffic Manager specific configurations
-      tm:
-        # If the deployment configurations for the Traffic Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml),
-        # add the customized configuration file under (wso2 -> deployment -> am -> pubStoreTM -> instanceOne -> config -> deployment.toml)
-        config: ""
-#          deployment.toml: |-
-#            # deployment configurations for the Traffic Manager profile of WSO2 API Manager v3.1.0 (<WSO2AM>/repository/conf/deployment.toml)
-
-      # Indicates whether the container is running.
-      livenessProbe:
-        # Number of seconds after the container has started before liveness probes are initiated.
-        initialDelaySeconds: 60
-        # How often (in seconds) to perform the probe.
-        periodSeconds: 10
-        # Indicates whether the container is ready to service requests.
-      readinessProbe:
-        # Number of seconds after the container has started before readiness probes are initiated.
-        initialDelaySeconds: 60
-        # How often (in seconds) to perform the probe.
-        periodSeconds: 10
-
-      resources:
-        # These are the resource recommendations for running WSO2 API Management product profiles with profile optimization.
-        requests:
-          memory: "1Gi"
-          cpu: "1000m"
-        limits:
-          memory: "2Gi"
-          cpu: "2000m"
-
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-3-svc-account"
 
+# Override sub chart parameters
 mysql-am:
   mysql:
     persistence:
-      storageClass: *storageClass
+      storageClass: *storage_class


### PR DESCRIPTION
## Purpose
> This PR performs $subject across all Kubernetes/Helm resources for WSO2 API Management patterns. This fixes https://github.com/wso2/kubernetes-apim/issues/416.

## Goals
> Set Solr indexing persistence to optional Kubernetes/Helm resources for WSO2 API Management patterns

## Test environment
> Helm version: 3.1.2
> GKE based Kubernetes Server version: `1.14`+, Git Version: `v1.14.10-gke.27`
> WSO2 Private Docker Registry images were utilized