### PR TITLE
[3.2.0] Upgrade the Base MySQL Helm Chart Version - 2020-08-25

### DIFF
--- a/advanced/mysql-am/requirements.yaml
+++ b/advanced/mysql-am/requirements.yaml
@@ -14,5 +14,5 @@
 
 dependencies:
   - name: mysql
-    version: "1.6.4"
+    version: "1.6.6"
     repository: "https://kubernetes-charts.storage.googleapis.com"


### PR DESCRIPTION
## Purpose
> This PR performs $subject fixing the linked issue.

## Goals
> Upgrade the Base MySQL Helm Chart Version - 2020-08-25

## Test environment
> Helm version: `3.2.4`
> GKE based Kubernetes Server version: `1.15`+, Git Version: `v1.15.12-gke.2`