### PR TITLE
[3.2.0] Add Input Option to Set Ingress Class and Annotations

### DIFF
--- a/advanced/am-pattern-1/README.md
+++ b/advanced/am-pattern-1/README.md
@@ -142,21 +142,21 @@ The output under the relevant column stands for the following.
 API Manager Publisher-DevPortal
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-1-am-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager service (`<wso2.deployment.am.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager service (`<wso2.deployment.am.ingress.management.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager service
 
 API Manager Gateway
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-1-am-gateway-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager's Gateway service (`<wso2.deployment.am.gateway.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager's Gateway service (`<wso2.deployment.am.ingress.gateway.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Gateway service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager' Gateway service
 
 API Manager Analytics Dashboard
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-1-am-analytics-dashboard-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service (`<.wso2.deployment.analytics.dashboard.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service (`<.wso2.deployment.analytics.dashboard.ingress.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager Analytics Dashboard service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager Analytics Dashboard service
 
@@ -169,16 +169,16 @@ If the defined hostnames are not backed by a DNS service, for the purpose of eva
 hostnames and the external IP in the `/etc/hosts` file at the client-side.
 
 ```
-<EXTERNAL-IP> <wso2.deployment.am.hostname> <wso2.deployment.am.gateway.hostname> <wso2.deployment.analytics.dashboard.hostname>
+<EXTERNAL-IP> <wso2.deployment.am.ingress.management.hostname> <wso2.deployment.am.ingress.gateway.hostname> <wso2.deployment.analytics.dashboard.ingress.hostname>
 ```
 
 ### 4. Access Management Consoles
 
-- API Manager Publisher: `https://<wso2.deployment.am.hostname>/publisher`
+- API Manager Publisher: `https://<wso2.deployment.am.ingress.management.hostname>/publisher`
 
-- API Manager DevPortal: `https://<wso2.deployment.am.hostname>/devportal`
+- API Manager DevPortal: `https://<wso2.deployment.am.ingress.management.hostname>/devportal`
 
-- API Manager Analytics Dashboard: `https://<wso2.deployment.analytics.dashboard.hostname>/analytics-dashboard`
+- API Manager Analytics Dashboard: `https://<wso2.deployment.analytics.dashboard.ingress.hostname>/analytics-dashboard`
 
 
 ## Configuration
@@ -216,8 +216,6 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 
 | Parameter                                                                   | Description                                                                               | Default Value               |
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
-| `wso2.deployment.am.hostname`                                               | Hostname for API Manager Publisher, DevPortal and Carbon Management Console               | `am.wso2.com`               |
-| `wso2.deployment.am.gateway.hostname`                                       | Hostname for API Manager Gateway                                                          | `gateway.am.wso2.com`       |
 | `wso2.deployment.am.dockerRegistry`                                         | Registry location of the Docker image to be used to create API Manager instances          | -                           |
 | `wso2.deployment.am.imageName`                                              | Name of the Docker image to be used to create API Manager instances                       | `wso2am`                    |
 | `wso2.deployment.am.imageTag`                                               | Tag of the image used to create API Manager instances                                     | 3.1.0                       |
@@ -231,6 +229,10 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 | `wso2.deployment.am.resources.limits.memory`                                | The maximum amount of memory that should be allocated for a Pod                           | 3Gi                         |
 | `wso2.deployment.am.resources.limits.cpu`                                   | The maximum amount of CPU that should be allocated for a Pod                              | 3000m                       |
 | `wso2.deployment.am.config`                                                 | Custom deployment configuration file (`<WSO2AM>/repository/conf/deployment.toml`)         | -                           |
+| `wso2.deployment.am.ingress.management.hostname`                            | Hostname for API Manager Admin Portal, Publisher, DevPortal and Carbon Management Console | `am.wso2.com`               |
+| `wso2.deployment.am.ingress.management.annotations`                         | Ingress resource annotations for API Manager management consoles                          | Community NGINX Ingress controller annotations         |
+| `wso2.deployment.am.ingress.gateway.hostname`                               | Hostname for API Manager Gateway                                                          | `gateway.am.wso2.com`       |
+| `wso2.deployment.am.ingress.gateway.annotations`                            | Ingress resource annotations for API Manager Gateway                                      | Community NGINX Ingress controller annotations         |
 
 **Note**: The above mentioned default, minimum resource amounts for running WSO2 API Manager server profiles are based on its [official documentation](https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/).
 
@@ -238,14 +240,13 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 
 | Parameter                                                                     | Description                                                                                                      | Default Value               |
 |-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `wso2.deployment.analytics.dashboard.hostname`                                | Hostname for API Manager Analytics Dashboard                                                                     | `analytics.am.wso2.com`     |
 | `wso2.deployment.analytics.dashboard.dockerRegistry`                          | Registry location of the Docker image to be used to create an API Manager Analytics instance                     | -                           |
-| `wso2.deployment.analytics.dashboard.imageName`                               | Name of the Docker image to be used to create an API Manager Analytics instance                                  | `wso2am-analytics-dashboard`    |
+| `wso2.deployment.analytics.dashboard.imageName`                               | Name of the Docker image to be used to create an API Manager Analytics instance                                  | `wso2am-analytics-dashboard` |
 | `wso2.deployment.analytics.dashboard.imageTag`                                | Tag of the image used to create an API Manager Analytics instance                                                | 3.1.0                       |
 | `wso2.deployment.analytics.dashboard.imagePullPolicy`                         | Refer to [doc](https://kubernetes.io/docs/concepts/containers/images#updating-images)                            | `Always`                    |
 | `wso2.deployment.analytics.dashboard.replicas`                                | Number of replicas of API Manager Analytics to be started                                                        | 1                           |
-| `wso2.deployment.analytics.dashboard.strategy.rollingUpdate.maxSurge`         | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 1                           |
-| `wso2.deployment.analytics.dashboard.strategy.rollingUpdate.maxUnavailable`   | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 0                           |
+| `wso2.deployment.analytics.dashboard.strategy.rollingUpdate.maxSurge`         | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 1                |
+| `wso2.deployment.analytics.dashboard.strategy.rollingUpdate.maxUnavailable`   | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 0                |
 | `wso2.deployment.analytics.dashboard.livenessProbe.initialDelaySeconds`       | Initial delay for the live-ness probe for API Manager Analytics node                                             | 20                          |
 | `wso2.deployment.analytics.dashboard.livenessProbe.periodSeconds`             | Period of the live-ness probe for API Manager Analytics node                                                     | 10                          |
 | `wso2.deployment.analytics.dashboard.readinessProbe.initialDelaySeconds`      | Initial delay for the readiness probe for API Manager Analytics node                                             | 20                          |
@@ -255,6 +256,8 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 | `wso2.deployment.analytics.dashboard.resources.limits.memory`                 | The maximum amount of memory that should be allocated for a Pod                                                  | 4Gi                         |
 | `wso2.deployment.analytics.dashboard.resources.limits.cpu`                    | The maximum amount of CPU that should be allocated for a Pod                                                     | 2000m                       |
 | `wso2.deployment.analytics.dashboard.config`                                  | Custom deployment configuration file (`<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml`)                       | -                           |
+| `wso2.deployment.analytics.dashboard.ingress.hostname`                        | Hostname for API Manager Analytics Dashboard                                                                     | `analytics.am.wso2.com`     |
+| `wso2.deployment.analytics.dashboard.ingress.annotations`                     | Ingress resource annotations for API Manager Analytics Dashboard                                                 | Community NGINX Ingress controller annotations         |
 
 ###### Analytics Worker Runtime Configurations
 

--- a/advanced/am-pattern-1/README.md
+++ b/advanced/am-pattern-1/README.md
@@ -156,7 +156,7 @@ API Manager Gateway
 API Manager Analytics Dashboard
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-1-am-analytics-dashboard-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service (`<.wso2.deployment.analytics.dashboard.ingress.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service (`<wso2.deployment.analytics.dashboard.ingress.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager Analytics Dashboard service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager Analytics Dashboard service
 

--- a/advanced/am-pattern-1/templates/NOTES.txt
+++ b/advanced/am-pattern-1/templates/NOTES.txt
@@ -11,21 +11,21 @@ Please follow these steps to access API Manager Publisher, DevPortal consoles an
   API Manager Publisher-DevPortal
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-1.resource.prefix" . }}-am-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager service ({{ .Values.wso2.deployment.am.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager service ({{ .Values.wso2.deployment.am.ingress.management.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager service
 
   API Manager Gateway
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-1.resource.prefix" . }}-am-gateway-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager's Gateway service ({{ .Values.wso2.deployment.am.gateway.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager's Gateway service ({{ .Values.wso2.deployment.am.ingress.gateway.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Gateway service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager' Gateway service
 
   API Manager Analytics Dashboard
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service ({{ .Values.wso2.deployment.analytics.dashboard.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service ({{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager Analytics Dashboard service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager Analytics Dashboard service
 
@@ -37,12 +37,12 @@ Please follow these steps to access API Manager Publisher, DevPortal consoles an
    If the defined hostnames are not backed by a DNS service, for the purpose of evaluation you may add an entry mapping the
    hostnames and the external IP in the `/etc/hosts` file at the client-side.
 
-   <EXTERNAL-IP> {{ .Values.wso2.deployment.am.hostname }} {{ .Values.wso2.deployment.am.gateway.hostname }} {{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+   <EXTERNAL-IP> {{ .Values.wso2.deployment.am.ingress.management.hostname }} {{ .Values.wso2.deployment.am.ingress.gateway.hostname }} {{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
 
 3. Navigate to the consoles in your browser of choice.
 
-   API Manager Publisher: https://{{ .Values.wso2.deployment.am.hostname }}/publisher
-   API Manager DevPortal: https://{{ .Values.wso2.deployment.am.hostname }}/devportal
-   API Manager Analytics Dashboard: https://{{ .Values.wso2.deployment.analytics.dashboard.hostname }}/analytics-dashboard
+   API Manager Publisher: https://{{ .Values.wso2.deployment.am.ingress.management.hostname }}/publisher
+   API Manager DevPortal: https://{{ .Values.wso2.deployment.am.ingress.management.hostname }}/devportal
+   API Manager Analytics Dashboard: https://{{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}/analytics-dashboard
 
 Please refer the official documentation at https://apim.docs.wso2.com/en/latest/ for additional information on WSO2 API Manager.

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-conf.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-conf.yaml
@@ -415,18 +415,18 @@ data:
         adminUsername: admin
         adminPassword: admin
         kmDcrUrl: https://{{ template "am-pattern-1.resource.prefix" . }}-am-service:9443/client-registration/v0.17/register
-        kmTokenUrlForRedirection: https://{{ .Values.wso2.deployment.am.hostname }}/oauth2
+        kmTokenUrlForRedirection: https://{{ .Values.wso2.deployment.am.ingress.management.hostname }}/oauth2
         kmTokenUrl: https://{{ template "am-pattern-1.resource.prefix" . }}-am-service:9443/oauth2
         kmUsername: admin
         kmPassword: admin
         portalAppContext: analytics-dashboard
         businessRulesAppContext : business-rules
         cacheTimeout: 30
-        baseUrl: https://{{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+        baseUrl: https://{{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
         grantType: authorization_code
         publisherUrl: https://{{ template "am-pattern-1.resource.prefix" . }}-am-service:9443
         devPortalUrl: https://{{ template "am-pattern-1.resource.prefix" . }}-am-service:9443
-        externalLogoutUrl: https://{{ .Values.wso2.deployment.am.hostname }}/oidc/logout
+        externalLogoutUrl: https://{{ .Values.wso2.deployment.am.ingress.management.hostname }}/oidc/logout
 
     wso2.dashboard:
       roles:

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-ingress.yaml
@@ -17,15 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.analytics.dashboard.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+{{ toYaml .Values.wso2.deployment.analytics.dashboard.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
     - hosts:
-        - {{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+        - {{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
   rules:
-    - host: {{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+    - host: {{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
       http:
         paths:
           - path: /

--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-conf.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-conf.yaml
@@ -28,7 +28,7 @@ data:
 data:
   deployment.toml: |-
     [server]
-    hostname = "{{ .Values.wso2.deployment.am.hostname }}"
+    hostname = "{{ .Values.wso2.deployment.am.ingress.management.hostname }}"
     node_ip = "$env{NODE_IP}"
     #offset=0
     mode = "single" #single or ha
@@ -90,8 +90,8 @@ data:
     password= "${admin.password}"
     ws_endpoint = "ws://localhost:9099"
     wss_endpoint = "wss://localhost:8099"
-    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.hostname }}"
-    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.hostname }}"
+    http_endpoint = "http://{{ .Values.wso2.deployment.am.ingress.gateway.hostname }}"
+    https_endpoint = "https://{{ .Values.wso2.deployment.am.ingress.gateway.hostname }}"
 
     #[apim.cache.gateway_token]
     #enable = true
@@ -175,7 +175,7 @@ data:
     #enable_token_hashing = false
 
     [apim.devportal]
-    url = "https://{{ .Values.wso2.deployment.am.hostname }}/devportal"
+    url = "https://{{ .Values.wso2.deployment.am.ingress.management.hostname }}/devportal"
     #enable_application_sharing = false
     #if application_sharing_type, application_sharing_impl both defined priority goes to application_sharing_impl
     #application_sharing_type = "default" #changed type, saml, default #todo: check the new config for rest api

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-conf.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-conf.yaml
@@ -28,7 +28,7 @@ data:
 data:
   deployment.toml: |-
     [server]
-    hostname = "{{ .Values.wso2.deployment.am.hostname }}"
+    hostname = "{{ .Values.wso2.deployment.am.ingress.management.hostname }}"
     node_ip = "$env{NODE_IP}"
     #offset=0
     mode = "single" #single or ha
@@ -90,8 +90,8 @@ data:
     password= "${admin.password}"
     ws_endpoint = "ws://localhost:9099"
     wss_endpoint = "wss://localhost:8099"
-    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.hostname }}"
-    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.hostname }}"
+    http_endpoint = "http://{{ .Values.wso2.deployment.am.ingress.gateway.hostname }}"
+    https_endpoint = "https://{{ .Values.wso2.deployment.am.ingress.gateway.hostname }}"
 
     #[apim.cache.gateway_token]
     #enable = true
@@ -175,7 +175,7 @@ data:
     #enable_token_hashing = false
 
     [apim.devportal]
-    url = "https://{{ .Values.wso2.deployment.am.hostname }}/devportal"
+    url = "https://{{ .Values.wso2.deployment.am.ingress.management.hostname }}/devportal"
     #enable_application_sharing = false
     #if application_sharing_type, application_sharing_impl both defined priority goes to application_sharing_impl
     #application_sharing_type = "default" #changed type, saml, default #todo: check the new config for rest api

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-gateway-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-gateway-ingress.yaml
@@ -17,15 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-1.resource.prefix" . }}-am-gateway-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.am.ingress.gateway.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+{{ toYaml .Values.wso2.deployment.am.ingress.gateway.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
   - hosts:
-    - {{ .Values.wso2.deployment.am.gateway.hostname }}
+    - {{ .Values.wso2.deployment.am.ingress.gateway.hostname }}
   rules:
-  - host: {{ .Values.wso2.deployment.am.gateway.hostname }}
+  - host: {{ .Values.wso2.deployment.am.ingress.gateway.hostname }}
     http:
       paths:
       - path: /

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-ingress.yaml
@@ -17,18 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-1.resource.prefix" . }}-am-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.am.ingress.management.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
-    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+{{ toYaml .Values.wso2.deployment.am.ingress.management.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
     - hosts:
-        - {{ .Values.wso2.deployment.am.hostname }}
+        - {{ .Values.wso2.deployment.am.ingress.management.hostname }}
   rules:
-    - host: {{ .Values.wso2.deployment.am.hostname }}
+    - host: {{ .Values.wso2.deployment.am.ingress.management.hostname }}
       http:
         paths:
           - path: /

--- a/advanced/am-pattern-1/values.yaml
+++ b/advanced/am-pattern-1/values.yaml
@@ -56,13 +56,6 @@ wso2:
           solrIndexedData: 50M
 
     am:
-      # Hostname for API Manager All In One deployment
-      hostname: "am.wso2.com"
-      # API Manager Gateway profile specific configurations
-      gateway:
-        # Hostname for Gateway profile
-        hostname: "gateway.am.wso2.com"
-
       # Container image configurations
       # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
       # dockerRegistry: ""
@@ -100,11 +93,28 @@ wso2:
 #        deployment.toml: |-
 #          # deployment configurations for the WSO2 API Manager v3.2.0 (<WSO2AM>/repository/conf/deployment.toml)
 
+      # Configure Ingresses
+      ingress:
+        management:
+          # Hostname for API Manager Carbon Management Console, Publisher, DevPortal and Admin Portal
+          hostname: "am.wso2.com"
+          # Annotations for the API Manager Publisher-DevPortal services Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            nginx.ingress.kubernetes.io/affinity: "cookie"
+            nginx.ingress.kubernetes.io/session-cookie-name: "route"
+            nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+        gateway:
+          # Hostname for Gateway profile
+          hostname: "gateway.am.wso2.com"
+          # Annotations for the API Manager Gateway service Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+
     analytics:
       dashboard:
-        # Hostname for API Manager Analytics Dashboard
-        hostname: "analytics.am.wso2.com"
-
         # Container image configurations
         # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
         # dockerRegistry: ""
@@ -153,6 +163,15 @@ wso2:
 #        config:
 #          deployment.yaml: |-
 #            # deployment configurations for the Dashboard profile of WSO2 API Manager Analytics v3.2.0 (<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml)
+
+        # Configure Ingress
+        ingress:
+          # Hostname for API Manager Analytics Dashboard
+          hostname: "analytics.am.wso2.com"
+          # Annotations for the API Manager Publisher-DevPortal services Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
       worker:
         # Container image configurations

--- a/advanced/am-pattern-1/values.yaml
+++ b/advanced/am-pattern-1/values.yaml
@@ -168,7 +168,7 @@ wso2:
         ingress:
           # Hostname for API Manager Analytics Dashboard
           hostname: "analytics.am.wso2.com"
-          # Annotations for the API Manager Publisher-DevPortal services Ingress
+          # Annotations for the API Manager Analytics Dashboard service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"

--- a/advanced/am-pattern-2/README.md
+++ b/advanced/am-pattern-2/README.md
@@ -142,21 +142,21 @@ The output under the relevant column stands for the following.
 API Manager Publisher-DevPortal
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-2-am-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager service (`<wso2.deployment.am.pubDevPortalTM.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager service (`<wso2.deployment.am.pubDevPortalTM.ingress.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager service
 
 API Manager Gateway
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-2-am-gateway-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager's Gateway service (`<wso2.deployment.am.gateway.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager's Gateway service (`<wso2.deployment.am.gateway.ingress.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Gateway service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager' Gateway service
 
 API Manager Analytics Dashboard
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-2-am-analytics-dashboard-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service (`<.wso2.deployment.analytics.dashboard.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service (`<wso2.deployment.analytics.dashboard.ingress.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager Analytics Dashboard service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager Analytics Dashboard service
 
@@ -169,16 +169,16 @@ If the defined hostnames are not backed by a DNS service, for the purpose of eva
 hostnames and the external IP in the `/etc/hosts` file at the client-side.
 
 ```
-<EXTERNAL-IP> <wso2.deployment.am.pubDevPortalTM.hostname> <wso2.deployment.am.gateway.hostname> <wso2.deployment.analytics.dashboard.hostname>
+<EXTERNAL-IP> <wso2.deployment.am.pubDevPortalTM.ingress.hostname> <wso2.deployment.am.gateway.ingress.hostname> <wso2.deployment.analytics.dashboard.ingress.hostname>
 ```
 
 ### 4. Access Management Consoles
 
-- API Manager Publisher: `https://<wso2.deployment.am.pubDevPortalTM.hostname>/publisher`
+- API Manager Publisher: `https://<wso2.deployment.am.pubDevPortalTM.ingress.hostname>/publisher`
 
-- API Manager DevPortal: `https://<wso2.deployment.am.pubDevPortalTM.hostname>/devportal`
+- API Manager DevPortal: `https://<wso2.deployment.am.pubDevPortalTM.ingress.hostname>/devportal`
 
-- API Manager Analytics Dashboard: `https://<wso2.deployment.analytics.dashboard.hostname>/analytics-dashboard`
+- API Manager Analytics Dashboard: `https://<wso2.deployment.analytics.dashboard.ingress.hostname>/analytics-dashboard`
 
 
 ## Configuration
@@ -224,7 +224,8 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 | `wso2.deployment.am.resources.requests.cpu`                                 | The minimum amount of CPU that should be allocated for running API Manager product profiles with profile optimization     | 1000m                       |
 | `wso2.deployment.am.resources.limits.memory`                                | The maximum amount of memory that should be allocated for running API Manager product profiles with profile optimization  | 2Gi                         |
 | `wso2.deployment.am.resources.limits.cpu`                                   | The maximum amount of CPU that should be allocated for running API Manager product profiles with profile optimization     | 2000m                       |
-| `wso2.deployment.am.gateway.hostname`                                       | Hostname for API Manager Gateway                                                          | `gateway.am.wso2.com`       |
+| `wso2.deployment.am.gateway.ingress.hostname`                               | Hostname for API Manager Gateway                                                          | `gateway.am.wso2.com`       |
+| `wso2.deployment.am.gateway.ingress.annotations`                            | Ingress resource annotations for API Manager Gateway                                      | Community NGINX Ingress controller annotations       |
 | `wso2.deployment.am.gateway.livenessProbe.initialDelaySeconds`              | Initial delay for the live-ness probe for API Manager Gateway                             | 60                          |
 | `wso2.deployment.am.gateway.livenessProbe.periodSeconds`                    | Period of the live-ness probe for API Manager Gateway                                     | 10                          |
 | `wso2.deployment.am.gateway.readinessProbe.initialDelaySeconds`             | Initial delay for the readiness probe for API Manager Gateway                             | 60                          |
@@ -241,7 +242,8 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 | `wso2.deployment.am.km.strategy.rollingUpdate.maxSurge`                     | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 2                         |
 | `wso2.deployment.am.km.strategy.rollingUpdate.maxUnavailable`               | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 0                         |
 | `wso2.deployment.am.km.config`                                              | Custom deployment configuration file for Key Manager profile (`<WSO2AM>/repository/conf/deployment.toml`)         | -                           |
-| `wso2.deployment.am.pubDevPortalTM.hostname`                                | Hostname for API Manager Publisher, DevPortal and Carbon Management Console               | `am.wso2.com`               |
+| `wso2.deployment.am.pubDevPortalTM.ingress.hostname`                        | Hostname for API Manager Publisher, DevPortal and Carbon Management Console               | `am.wso2.com`               |
+| `wso2.deployment.am.pubDevPortalTM.ingress.annotations`                     | Ingress resource annotations for API Manager management consoles                          | Community NGINX Ingress controller annotations               |
 | `wso2.deployment.am.pubDevPortalTM.livenessProbe.initialDelaySeconds`       | Initial delay for the live-ness probe for API Manager node                                | 180                         |
 | `wso2.deployment.am.pubDevPortalTM.livenessProbe.periodSeconds`             | Period of the live-ness probe for API Manager node                                        | 10                          |
 | `wso2.deployment.am.pubDevPortalTM.readinessProbe.initialDelaySeconds`      | Initial delay for the readiness probe for API Manager node                                | 180                         |
@@ -258,7 +260,6 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 
 | Parameter                                                                     | Description                                                                                                      | Default Value               |
 |-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `wso2.deployment.analytics.dashboard.hostname`                                | Hostname for API Manager Analytics Dashboard                                                                     | `analytics.am.wso2.com`     |
 | `wso2.deployment.analytics.dashboard.dockerRegistry`                          | Registry location of the Docker image to be used to create an API Manager Analytics instance                     | -                           |
 | `wso2.deployment.analytics.dashboard.imageName`                               | Name of the Docker image to be used to create an API Manager Analytics instance                                  | `wso2am-analytics-dashboard`    |
 | `wso2.deployment.analytics.dashboard.imageTag`                                | Tag of the image used to create an API Manager Analytics instance                                                | 3.1.0                       |
@@ -275,6 +276,8 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 | `wso2.deployment.analytics.dashboard.resources.limits.memory`                 | The maximum amount of memory that should be allocated for a Pod                                                  | 4Gi                         |
 | `wso2.deployment.analytics.dashboard.resources.limits.cpu`                    | The maximum amount of CPU that should be allocated for a Pod                                                     | 2000m                       |
 | `wso2.deployment.analytics.dashboard.config`                                  | Custom deployment configuration file (`<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml`)                       | -                           |
+| `wso2.deployment.analytics.dashboard.ingress.hostname`                        | Hostname for API Manager Analytics Dashboard                                                                     | `analytics.am.wso2.com`     |
+| `wso2.deployment.analytics.dashboard.ingress.annotations`                     | Ingress resource annotations for API Manager Analytics Dashboard                                                 | Community NGINX Ingress controller annotations         |
 
 ###### Analytics Worker Runtime Configurations
 

--- a/advanced/am-pattern-2/templates/NOTES.txt
+++ b/advanced/am-pattern-2/templates/NOTES.txt
@@ -11,21 +11,21 @@ Please follow these steps to access API Manager Publisher, DevPortal consoles an
   API Manager Publisher-DevPortal
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-2.resource.prefix" . }}-am-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager service ({{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager service ({{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager service
 
   API Manager Gateway
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-2.resource.prefix" . }}-am-gateway-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager's Gateway service ({{ .Values.wso2.deployment.am.gateway.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager's Gateway service ({{ .Values.wso2.deployment.am.gateway.ingress.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Gateway service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager' Gateway service
 
   API Manager Analytics Dashboard
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-2.resource.prefix" . }}-am-analytics-dashboard-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service ({{ .Values.wso2.deployment.analytics.dashboard.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service ({{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager Analytics Dashboard service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager Analytics Dashboard service
 
@@ -37,12 +37,12 @@ Please follow these steps to access API Manager Publisher, DevPortal consoles an
    If the defined hostnames are not backed by a DNS service, for the purpose of evaluation you may add an entry mapping the
    hostnames and the external IP in the `/etc/hosts` file at the client-side.
 
-   <EXTERNAL-IP> {{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }} {{ .Values.wso2.deployment.am.gateway.hostname }} {{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+   <EXTERNAL-IP> {{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }} {{ .Values.wso2.deployment.am.gateway.ingress.hostname }} {{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
 
 3. Navigate to the consoles in your browser of choice.
 
-   API Manager Publisher: https://{{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}/publisher
-   API Manager DevPortal: https://{{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}/devportal
-   API Manager Analytics Dashboard: https://{{ .Values.wso2.deployment.analytics.dashboard.hostname }}/analytics-dashboard
+   API Manager Publisher: https://{{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}/publisher
+   API Manager DevPortal: https://{{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}/devportal
+   API Manager Analytics Dashboard: https://{{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}/analytics-dashboard
 
 Please refer the official documentation at https://apim.docs.wso2.com/en/latest/ for additional information on WSO2 API Manager.

--- a/advanced/am-pattern-2/templates/am-analytics/dashboard/wso2am-pattern-2-am-analytics-dashboard-conf.yaml
+++ b/advanced/am-pattern-2/templates/am-analytics/dashboard/wso2am-pattern-2-am-analytics-dashboard-conf.yaml
@@ -414,18 +414,18 @@ data:
         adminUsername: admin
         adminPassword: admin
         kmDcrUrl: https://{{ template "am-pattern-2.resource.prefix" . }}-am-service:9443/client-registration/v0.17/register
-        kmTokenUrlForRedirection: https://{{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}/oauth2
+        kmTokenUrlForRedirection: https://{{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}/oauth2
         kmTokenUrl: https://{{ template "am-pattern-2.resource.prefix" . }}-am-service:9443/oauth2
         kmUsername: admin
         kmPassword: admin
         portalAppContext: analytics-dashboard
         businessRulesAppContext : business-rules
         cacheTimeout: 30
-        baseUrl: https://{{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+        baseUrl: https://{{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
         grantType: authorization_code
         publisherUrl: https://{{ template "am-pattern-2.resource.prefix" . }}-am-service:9443
         devPortalUrl: https://{{ template "am-pattern-2.resource.prefix" . }}-am-service:9443
-        externalLogoutUrl: https://{{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}/oidc/logout
+        externalLogoutUrl: https://{{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}/oidc/logout
 
     wso2.dashboard:
       roles:

--- a/advanced/am-pattern-2/templates/am-analytics/dashboard/wso2am-pattern-2-am-analytics-dashboard-ingress.yaml
+++ b/advanced/am-pattern-2/templates/am-analytics/dashboard/wso2am-pattern-2-am-analytics-dashboard-ingress.yaml
@@ -17,15 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-2.resource.prefix" . }}-am-analytics-dashboard-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.analytics.dashboard.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+{{ toYaml .Values.wso2.deployment.analytics.dashboard.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
   - hosts:
-    - {{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+    - {{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
   rules:
-  - host: {{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+  - host: {{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
     http:
       paths:
       - path: /

--- a/advanced/am-pattern-2/templates/am/gateway/wso2am-pattern-2-am-gateway-conf.yaml
+++ b/advanced/am-pattern-2/templates/am/gateway/wso2am-pattern-2-am-gateway-conf.yaml
@@ -28,7 +28,7 @@ data:
 data:
   deployment.toml: |-
     [server]
-    hostname = "{{ .Values.wso2.deployment.am.gateway.hostname }}"
+    hostname = "{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
     node_ip = "$env{NODE_IP}"
     server_role = "gateway-worker"
 

--- a/advanced/am-pattern-2/templates/am/gateway/wso2am-pattern-2-am-gateway-ingress.yaml
+++ b/advanced/am-pattern-2/templates/am/gateway/wso2am-pattern-2-am-gateway-ingress.yaml
@@ -17,15 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-2.resource.prefix" . }}-am-gateway-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.am.gateway.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+{{ toYaml .Values.wso2.deployment.am.gateway.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
   - hosts:
-    - {{ .Values.wso2.deployment.am.gateway.hostname }}
+    - {{ .Values.wso2.deployment.am.gateway.ingress.hostname }}
   rules:
-  - host: {{ .Values.wso2.deployment.am.gateway.hostname }}
+  - host: {{ .Values.wso2.deployment.am.gateway.ingress.hostname }}
     http:
       paths:
       - path: /

--- a/advanced/am-pattern-2/templates/am/pub-devportal-tm/instance-1/wso2am-pattern-2-am-conf.yaml
+++ b/advanced/am-pattern-2/templates/am/pub-devportal-tm/instance-1/wso2am-pattern-2-am-conf.yaml
@@ -28,7 +28,7 @@ data:
 data:
   deployment.toml: |-
     [server]
-    hostname = "{{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}"
+    hostname = "{{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}"
     node_ip = "$env{NODE_IP}"
     #offset=0
     mode = "single" #single or ha
@@ -90,8 +90,8 @@ data:
     password= "${admin.password}"
     ws_endpoint = "ws://localhost:9099"
     wss_endpoint = "wss://localhost:8099"
-    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.hostname }}"
-    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.hostname }}"
+    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
+    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
 
     #[apim.cache.gateway_token]
     #enable = true
@@ -175,7 +175,7 @@ data:
     #enable_token_hashing = false
 
     [apim.devportal]
-    url = "https://{{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}/devportal"
+    url = "https://{{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}/devportal"
     #enable_application_sharing = false
     #if application_sharing_type, application_sharing_impl both defined priority goes to application_sharing_impl
     #application_sharing_type = "default" #changed type, saml, default #todo: check the new config for rest api

--- a/advanced/am-pattern-2/templates/am/pub-devportal-tm/instance-2/wso2am-pattern-2-am-conf.yaml
+++ b/advanced/am-pattern-2/templates/am/pub-devportal-tm/instance-2/wso2am-pattern-2-am-conf.yaml
@@ -28,7 +28,7 @@ data:
 data:
   deployment.toml: |-
     [server]
-    hostname = "{{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}"
+    hostname = "{{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}"
     node_ip = "$env{NODE_IP}"
     #offset=0
     mode = "single" #single or ha
@@ -90,8 +90,8 @@ data:
     password= "${admin.password}"
     ws_endpoint = "ws://localhost:9099"
     wss_endpoint = "wss://localhost:8099"
-    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.hostname }}"
-    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.hostname }}"
+    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
+    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
 
     #[apim.cache.gateway_token]
     #enable = true
@@ -175,7 +175,7 @@ data:
     #enable_token_hashing = false
 
     [apim.devportal]
-    url = "https://{{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}/devportal"
+    url = "https://{{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}/devportal"
     #enable_application_sharing = false
     #if application_sharing_type, application_sharing_impl both defined priority goes to application_sharing_impl
     #application_sharing_type = "default" #changed type, saml, default #todo: check the new config for rest api

--- a/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-ingress.yaml
+++ b/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-ingress.yaml
@@ -17,18 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-2.resource.prefix" . }}-am-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.am.pubDevPortalTM.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
-    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+{{ toYaml .Values.wso2.deployment.am.pubDevPortalTM.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
   - hosts:
-    - {{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}
+    - {{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}
   rules:
-  - host: {{ .Values.wso2.deployment.am.pubDevPortalTM.hostname }}
+  - host: {{ .Values.wso2.deployment.am.pubDevPortalTM.ingress.hostname }}
     http:
       paths:
       - path: /

--- a/advanced/am-pattern-2/values.yaml
+++ b/advanced/am-pattern-2/values.yaml
@@ -238,7 +238,7 @@ wso2:
         ingress:
           # Hostname for API Manager Analytics Dashboard
           hostname: "analytics.am.wso2.com"
-          # Annotations for the API Manager Publisher-DevPortal services Ingress
+          # Annotations for the API Manager Analytics Dashboard service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"

--- a/advanced/am-pattern-2/values.yaml
+++ b/advanced/am-pattern-2/values.yaml
@@ -76,9 +76,6 @@ wso2:
 
       # API Manager's Gateway specific configurations
       gateway:
-        # Hostname for Gateway profile
-        hostname: "gateway.am.wso2.com"
-
         # Indicates whether the container is running
         livenessProbe:
           # Number of seconds after the container has started before liveness probes are initiated
@@ -109,6 +106,15 @@ wso2:
 #          deployment.toml: |-
 #            # deployment configurations for the Gateway profile of WSO2 API Manager v3.2.0 (<WSO2AM>/repository/conf/deployment.toml)
 
+        # Configure Ingress
+        ingress:
+          # Hostname for Gateway profile
+          hostname: "gateway.am.wso2.com"
+          # Annotations for the API Manager Gateway service Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+
       # API Manager's Key Manager specific configurations
       km:
         livenessProbe:
@@ -133,9 +139,6 @@ wso2:
 #            # deployment configurations for the Key Manager profile of WSO2 API Manager v3.2.0 (<WSO2AM>/repository/conf/deployment.toml)
 
       pubDevPortalTM:
-        # Hostname for Publisher-DevPortal deployment
-        hostname: "am.wso2.com"
-
         # Indicates whether the container is running
         livenessProbe:
           # Number of seconds after the container has started before liveness probes are initiated
@@ -155,6 +158,18 @@ wso2:
 #          deployment.toml: |-
 #            # deployment configurations for All-In-One WSO2 API Manager v3.2.0 (<WSO2AM>/repository/conf/deployment.toml)
 
+        # Configure Ingress
+        ingress:
+          # Hostname for API Manager Carbon Management Console, Publisher, DevPortal and Admin Portal
+          hostname: "am.wso2.com"
+          # Annotations for the API Manager Publisher-DevPortal services Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            nginx.ingress.kubernetes.io/affinity: "cookie"
+            nginx.ingress.kubernetes.io/session-cookie-name: "route"
+            nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+
         resources:
           # These are the resource recommendations for running WSO2 API Management All-In-One deployment
           # as per official documentation (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
@@ -167,9 +182,6 @@ wso2:
 
     analytics:
       dashboard:
-        # Hostname for API Manager Analytics Dashboard
-        hostname: "analytics.am.wso2.com"
-
         # Container image configurations
         # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
         # dockerRegistry: ""
@@ -221,6 +233,15 @@ wso2:
           limits:
             memory: "4Gi"
             cpu: "2000m"
+
+        # Configure Ingress
+        ingress:
+          # Hostname for API Manager Analytics Dashboard
+          hostname: "analytics.am.wso2.com"
+          # Annotations for the API Manager Publisher-DevPortal services Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
       worker:
         # Container image configurations

--- a/advanced/am-pattern-3/README.md
+++ b/advanced/am-pattern-3/README.md
@@ -142,28 +142,28 @@ The output under the relevant column stands for the following.
 API Manager Publisher
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-3-am-publisher-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager's Publisher service (`<wso2.deployment.am.publisher.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager's Publisher service (`<wso2.deployment.am.publisher.ingress.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Publisher service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager's Publisher service
 
 API Manager DevPortal
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-3-am-devportal-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager's DevPortal service (`<wso2.deployment.am.devportal.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager's DevPortal service (`<wso2.deployment.am.devportal.ingress.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's DevPortal service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager service
 
 API Manager Gateway
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-3-am-gateway-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager's Gateway service (`<wso2.deployment.am.gateway.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager's Gateway service (`<wso2.deployment.am.gateway.ingress.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Gateway service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager's DevPortal service
 
 API Manager Analytics Dashboard
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2am-pattern-3-am-analytics-dashboard-ingress`)
-- HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service (`<wso2.deployment.analytics.dashboard.hostname>`)
+- HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service (`<wso2.deployment.analytics.dashboard.ingress.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager Analytics Dashboard service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the API Manager Analytics Dashboard service
 
@@ -176,16 +176,16 @@ If the defined hostnames are not backed by a DNS service, for the purpose of eva
 hostnames and the external IP in the `/etc/hosts` file at the client-side.
 
 ```
-<EXTERNAL-IP> <wso2.deployment.am.publisher.hostname> <wso2.deployment.am.gateway.hostname> <wso2.deployment.am.devportal.hostname> <wso2.deployment.analytics.dashboard.hostname>
+<EXTERNAL-IP> <wso2.deployment.am.publisher.ingress.hostname> <wso2.deployment.am.gateway.ingress.hostname> <wso2.deployment.am.devportal.ingress.hostname> <wso2.deployment.analytics.dashboard.ingress.hostname>
 ```
 
 ### 4. Access Management Consoles
 
-- API Manager Publisher: `https://<wso2.deployment.am.publisher.hostname>/publisher`
+- API Manager Publisher: `https://<wso2.deployment.am.publisher.ingress.hostname>/publisher`
 
-- API Manager DevPortal: `https://<wso2.deployment.am.devportal.hostname>/devportal`
+- API Manager DevPortal: `https://<wso2.deployment.am.devportal.ingress.hostname>/devportal`
 
-- API Manager Analytics Dashboard: `https://<wso2.deployment.analytics.dashboard.hostname>/analytics-dashboard`
+- API Manager Analytics Dashboard: `https://<wso2.deployment.analytics.dashboard.ingress.hostname>/analytics-dashboard`
 
 
 ## Configuration
@@ -235,7 +235,8 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 | `wso2.deployment.am.livenessProbe.periodSeconds`                            | Period of the live-ness probe for API Manager optimized profile                           | 10                          |
 | `wso2.deployment.am.readinessProbe.initialDelaySeconds`                     | Initial delay for the readiness probe for API Manager optimized profile                   | 60                          |
 | `wso2.deployment.am.readinessProbe.periodSeconds`                           | Period of the readiness probe for API Manager optimized profile                           | 10                          |
-| `wso2.deployment.am.gateway.hostname`                                       | Hostname for API Manager Gateway                                                          | `gateway.am.wso2.com`       |
+| `wso2.deployment.am.gateway.ingress.hostname`                               | Hostname for API Manager Gateway                                                          | `gateway.am.wso2.com`       |
+| `wso2.deployment.am.gateway.ingress.annotations`                            | Ingress resource annotations for API Manager Gateway                                      | Community NGINX Ingress controller annotations       |
 | `wso2.deployment.am.gateway.replicas`                                       | Number of replicas of API Manager Gateway to be started                                   | 2                           |
 | `wso2.deployment.am.gateway.strategy.rollingUpdate.maxSurge`                | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 2                         |
 | `wso2.deployment.am.gateway.strategy.rollingUpdate.maxUnavailable`          | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 0                         |
@@ -244,9 +245,11 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 | `wso2.deployment.am.km.strategy.rollingUpdate.maxSurge`                     | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 2                         |
 | `wso2.deployment.am.km.strategy.rollingUpdate.maxUnavailable`               | Refer to [doc](https://v1-14.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#deploymentstrategy-v1-apps)  | 0                         |
 | `wso2.deployment.am.km.config`                                              | Custom deployment configuration file for Key Manager profile (`<WSO2AM>/repository/conf/deployment.toml`)         | -                           |
-| `wso2.deployment.am.publisher.hostname`                                     | Hostname for API Manager Publisher                                                        | `publisher.am.wso2.com`     |
+| `wso2.deployment.am.publisher.ingress.hostname`                             | Hostname for API Manager Publisher                                                          | `publisher.am.wso2.com`       |
+| `wso2.deployment.am.publisher.ingress.annotations`                          | Ingress resource annotations for API Manager Publisher                                      | Community NGINX Ingress controller annotations       |
 | `wso2.deployment.am.publisher.config`                                       | Custom deployment configuration file for Publisher profile (`<WSO2AM>/repository/conf/deployment.toml`)         | -                           |
-| `wso2.deployment.am.devportal.hostname`                                     | Hostname for API Manager DevPortal                                                        | `devportal.am.wso2.com`     |
+| `wso2.deployment.am.devportal.ingress.hostname`                             | Hostname for API Manager DevPortal                                                          | `devportal.am.wso2.com`       |
+| `wso2.deployment.am.devportal.ingress.annotations`                          | Ingress resource annotations for API Manager DevPortal                                      | Community NGINX Ingress controller annotations       |
 | `wso2.deployment.am.devportal.config`                                       | Custom deployment configuration file for DevPortal profile (`<WSO2AM>/repository/conf/deployment.toml`)         | -                           |
 | `wso2.deployment.am.tm.config`                                              | Custom deployment configuration file for Traffic Manager profile (`<WSO2AM>/repository/conf/deployment.toml`)         | -                           |
 
@@ -254,7 +257,6 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 
 | Parameter                                                                     | Description                                                                                                      | Default Value               |
 |-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `wso2.deployment.analytics.dashboard.hostname`                                | Hostname for API Manager Analytics Dashboard                                                                     | `analytics.am.wso2.com`     |
 | `wso2.deployment.analytics.dashboard.dockerRegistry`                          | Registry location of the Docker image to be used to create an API Manager Analytics instance                     | -                           |
 | `wso2.deployment.analytics.dashboard.imageName`                               | Name of the Docker image to be used to create an API Manager Analytics instance                                  | `wso2am-analytics-dashboard`    |
 | `wso2.deployment.analytics.dashboard.imageTag`                                | Tag of the image used to create an API Manager Analytics instance                                                | 3.1.0                       |
@@ -271,6 +273,8 @@ If you do not have an active WSO2 subscription, **do not change** the parameters
 | `wso2.deployment.analytics.dashboard.resources.limits.memory`                 | The maximum amount of memory that should be allocated for a Pod                                                  | 4Gi                         |
 | `wso2.deployment.analytics.dashboard.resources.limits.cpu`                    | The maximum amount of CPU that should be allocated for a Pod                                                     | 2000m                       |
 | `wso2.deployment.analytics.dashboard.config`                                  | Custom deployment configuration file (`<WSO2AM_ANALYTICS>/conf/dashboard/deployment.yaml`)                       | -                           |
+| `wso2.deployment.analytics.dashboard.ingress.hostname`                        | Hostname for API Manager Analytics Dashboard                                                                     | `analytics.am.wso2.com`     |
+| `wso2.deployment.analytics.dashboard.ingress.annotations`                     | Ingress resource annotations for API Manager Analytics Dashboard                                                 | Community NGINX Ingress controller annotations         |
 
 ###### Analytics Worker Runtime Configurations
 

--- a/advanced/am-pattern-3/templates/NOTES.txt
+++ b/advanced/am-pattern-3/templates/NOTES.txt
@@ -11,28 +11,28 @@ Please follow these steps to access API Manager Publisher, DevPortal consoles an
   API Manager Publisher
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager's Publisher service ({{ .Values.wso2.deployment.am.publisher.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager's Publisher service ({{ .Values.wso2.deployment.am.publisher.ingress.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Publisher service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager's Publisher service
 
   API Manager DevPortal
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager's DevPortal service ({{ .Values.wso2.deployment.am.devportal.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager's DevPortal service ({{ .Values.wso2.deployment.am.devportal.ingress.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's DevPortal service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager service
 
   API Manager Gateway
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-3.resource.prefix" . }}-am-gateway-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager's Gateway service ({{ .Values.wso2.deployment.am.gateway.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager's Gateway service ({{ .Values.wso2.deployment.am.gateway.ingress.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Gateway service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager's DevPortal service
 
   API Manager Analytics Dashboard
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-pattern-3.resource.prefix" . }}-am-analytics-dashboard-ingress)
-  - HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service ({{ .Values.wso2.deployment.analytics.dashboard.hostname }})
+  - HOSTS: Hostname of the WSO2 API Manager Analytics Dashboard service ({{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager Analytics Dashboard service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the API Manager Analytics Dashboard service
 
@@ -44,12 +44,12 @@ Please follow these steps to access API Manager Publisher, DevPortal consoles an
    If the defined hostnames are not backed by a DNS service, for the purpose of evaluation you may add an entry mapping the
    hostnames and the external IP in the `/etc/hosts` file at the client-side.
 
-   <EXTERNAL-IP> {{ .Values.wso2.deployment.am.publisher.hostname }} {{ .Values.wso2.deployment.am.devportal.hostname }} {{ .Values.wso2.deployment.am.gateway.hostname }} {{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+   <EXTERNAL-IP> {{ .Values.wso2.deployment.am.publisher.ingress.hostname }} {{ .Values.wso2.deployment.am.devportal.ingress.hostname }} {{ .Values.wso2.deployment.am.gateway.ingress.hostname }} {{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
 
 3. Navigate to the consoles in your browser of choice.
 
-   API Manager Publisher: https://{{ .Values.wso2.deployment.am.publisher.hostname }}/publisher
-   API Manager DevPortal: https://{{ .Values.wso2.deployment.am.devportal.hostname }}/devportal
-   API Manager Analytics Dashboard: https://{{ .Values.wso2.deployment.analytics.dashboard.hostname }}/analytics-dashboard
+   API Manager Publisher: https://{{ .Values.wso2.deployment.am.publisher.ingress.hostname }}/publisher
+   API Manager DevPortal: https://{{ .Values.wso2.deployment.am.devportal.ingress.hostname }}/devportal
+   API Manager Analytics Dashboard: https://{{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}/analytics-dashboard
 
 Please refer the official documentation at https://apim.docs.wso2.com/en/latest/ for additional information on WSO2 API Manager.

--- a/advanced/am-pattern-3/templates/am-analytics/dashboard/wso2am-pattern-3-am-analytics-dashboard-conf.yaml
+++ b/advanced/am-pattern-3/templates/am-analytics/dashboard/wso2am-pattern-3-am-analytics-dashboard-conf.yaml
@@ -414,18 +414,18 @@ data:
         adminUsername: admin
         adminPassword: admin
         kmDcrUrl: https://{{ template "am-pattern-3.resource.prefix" . }}-am-publisher-service:9443/client-registration/v0.17/register
-        kmTokenUrlForRedirection: https://{{ .Values.wso2.deployment.am.publisher.hostname }}/oauth2
+        kmTokenUrlForRedirection: https://{{ .Values.wso2.deployment.am.publisher.ingress.hostname }}/oauth2
         kmTokenUrl: https://{{ template "am-pattern-3.resource.prefix" . }}-am-publisher-service:9443/oauth2
         kmUsername: admin
         kmPassword: admin
         portalAppContext: analytics-dashboard
         businessRulesAppContext : business-rules
         cacheTimeout: 30
-        baseUrl: https://{{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+        baseUrl: https://{{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
         grantType: authorization_code
         publisherUrl: https://{{ template "am-pattern-3.resource.prefix" . }}-am-publisher-service:9443
         devPortalUrl: https://{{ template "am-pattern-3.resource.prefix" . }}-am-devportal-service:9443
-        externalLogoutUrl: https://{{ .Values.wso2.deployment.am.publisher.hostname }}/oidc/logout
+        externalLogoutUrl: https://{{ .Values.wso2.deployment.am.publisher.ingress.hostname }}/oidc/logout
 
     wso2.dashboard:
       roles:

--- a/advanced/am-pattern-3/templates/am-analytics/dashboard/wso2am-pattern-3-am-analytics-dashboard-ingress.yaml
+++ b/advanced/am-pattern-3/templates/am-analytics/dashboard/wso2am-pattern-3-am-analytics-dashboard-ingress.yaml
@@ -17,15 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-3.resource.prefix" . }}-am-analytics-dashboard-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.analytics.dashboard.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+{{ toYaml .Values.wso2.deployment.analytics.dashboard.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
   - hosts:
-    - {{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+    - {{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
   rules:
-  - host: {{ .Values.wso2.deployment.analytics.dashboard.hostname }}
+  - host: {{ .Values.wso2.deployment.analytics.dashboard.ingress.hostname }}
     http:
       paths:
       - path: /

--- a/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-conf.yaml
+++ b/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-conf.yaml
@@ -28,7 +28,7 @@ data:
 data:
   deployment.toml: |-
     [server]
-    hostname = "{{ .Values.wso2.deployment.am.devportal.hostname }}"
+    hostname = "{{ .Values.wso2.deployment.am.devportal.ingress.hostname }}"
     node_ip = "$env{NODE_IP}"
     server_role="api-devportal"
 
@@ -81,8 +81,8 @@ data:
     username= "${admin.username}"
     password= "${admin.password}"
     ws_endpoint= "ws://api.gw.wso2.com:9099"
-    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.hostname }}"
-    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.hostname }}"
+    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
+    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
     show_as_token_endpoint_url = true
 
     [apim.analytics]

--- a/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-ingress.yaml
+++ b/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-ingress.yaml
@@ -17,18 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.am.devportal.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
-    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+{{ toYaml .Values.wso2.deployment.am.devportal.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
     - hosts:
-        - {{ .Values.wso2.deployment.am.devportal.hostname }}
+        - {{ .Values.wso2.deployment.am.devportal.ingress.hostname }}
   rules:
-    - host: {{ .Values.wso2.deployment.am.devportal.hostname }}
+    - host: {{ .Values.wso2.deployment.am.devportal.ingress.hostname }}
       http:
         paths:
         - path: /

--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-conf.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-conf.yaml
@@ -28,7 +28,7 @@ data:
 data:
   deployment.toml: |-
     [server]
-    hostname = "{{ .Values.wso2.deployment.am.gateway.hostname }}"
+    hostname = "{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
     node_ip = "$env{NODE_IP}"
     server_role = "gateway-worker"
 

--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-ingress.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-ingress.yaml
@@ -17,15 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-3.resource.prefix" . }}-am-gateway-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.am.gateway.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+{{ toYaml .Values.wso2.deployment.am.gateway.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
   - hosts:
-    - {{ .Values.wso2.deployment.am.gateway.hostname }}
+    - {{ .Values.wso2.deployment.am.gateway.ingress.hostname }}
   rules:
-  - host: {{ .Values.wso2.deployment.am.gateway.hostname }}
+  - host: {{ .Values.wso2.deployment.am.gateway.ingress.hostname }}
     http:
       paths:
       - path: /

--- a/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-conf.yaml
+++ b/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-conf.yaml
@@ -28,7 +28,7 @@ data:
 data:
   deployment.toml: |-
     [server]
-    hostname = "{{ .Values.wso2.deployment.am.publisher.hostname }}"
+    hostname = "{{ .Values.wso2.deployment.am.publisher.ingress.hostname }}"
     node_ip = "$env{NODE_IP}"
     server_role = "api-publisher"
 
@@ -74,8 +74,8 @@ data:
     service_url= "https://{{ template "am-pattern-3.resource.prefix" . }}-am-gateway-service:${mgt.transport.https.port}${carbon.context}services/"
     username= "${admin.username}"
     password= "${admin.password}"
-    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.hostname }}"
-    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.hostname }}"
+    http_endpoint = "http://{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
+    https_endpoint = "https://{{ .Values.wso2.deployment.am.gateway.ingress.hostname }}"
 
 
     # key manager implementation
@@ -119,7 +119,7 @@ data:
     enable = true
 
     [apim.devportal]
-    url = "https://{{ .Values.wso2.deployment.am.devportal.hostname }}/devportal"
+    url = "https://{{ .Values.wso2.deployment.am.devportal.ingress.hostname }}/devportal"
 
     [apim.workflow]
     enable = false

--- a/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-ingress.yaml
+++ b/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-ingress.yaml
@@ -17,18 +17,16 @@ kind: Ingress
 metadata:
   name: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.am.publisher.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
-    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+{{ toYaml .Values.wso2.deployment.am.publisher.ingress.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
     - hosts:
-        - {{ .Values.wso2.deployment.am.publisher.hostname }}
+        - {{ .Values.wso2.deployment.am.publisher.ingress.hostname }}
   rules:
-    - host: {{ .Values.wso2.deployment.am.publisher.hostname }}
+    - host: {{ .Values.wso2.deployment.am.publisher.ingress.hostname }}
       http:
         paths:
         - path: /

--- a/advanced/am-pattern-3/values.yaml
+++ b/advanced/am-pattern-3/values.yaml
@@ -89,8 +89,14 @@ wso2:
 
       # API Manager's Gateway specific configurations
       gateway:
-        # Hostname for Gateway profile
-        hostname: "gateway.am.wso2.com"
+        # Configure Ingress
+        ingress:
+          # Hostname for Gateway profile
+          hostname: "gateway.am.wso2.com"
+          # Annotations for the API Manager Gateway service Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
         # Number of deployment replicas
         replicas: 2
@@ -122,8 +128,17 @@ wso2:
 
       # API Manager's Publisher specific configurations
       publisher:
-        # Hostname for Publisher profile
-        hostname: "publisher.am.wso2.com"
+        # Configure Ingress
+        ingress:
+          # Hostname for Publisher profile
+          hostname: "publisher.am.wso2.com"
+          # Annotations for the API Manager Publisher service Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            nginx.ingress.kubernetes.io/affinity: "cookie"
+            nginx.ingress.kubernetes.io/session-cookie-name: "route"
+            nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
 
         # If the deployment configurations for the Publisher profile of WSO2 API Manager v3.2.0 (<WSO2AM>/repository/conf/deployment.toml),
         # add the customized configuration file under (wso2 -> deployment -> am -> publisher -> config -> deployment.toml)
@@ -133,8 +148,17 @@ wso2:
 
       # API Manager's DevPortal specific configurations
       devportal:
-        # Hostname for DevPortal profile
-        hostname: "devportal.am.wso2.com"
+        # Configure Ingress
+        ingress:
+          # Hostname for DevPortal profile
+          hostname: "devportal.am.wso2.com"
+          # Annotations for the API Manager DevPortal service Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            nginx.ingress.kubernetes.io/affinity: "cookie"
+            nginx.ingress.kubernetes.io/session-cookie-name: "route"
+            nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
 
         # If the deployment configurations for the DevPortal profile of WSO2 API Manager v3.2.0 (<WSO2AM>/repository/conf/deployment.toml),
         # add the customized configuration file under (wso2 -> deployment -> am -> devportal -> config -> deployment.toml)
@@ -152,9 +176,6 @@ wso2:
 
     analytics:
       dashboard:
-        # Hostname for API Manager Analytics Dashboard
-        hostname: "analytics.am.wso2.com"
-
         # Container image configurations
         # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
         # dockerRegistry: ""
@@ -205,6 +226,15 @@ wso2:
           limits:
             memory: "4Gi"
             cpu: "2000m"
+
+        # Configure Ingress
+        ingress:
+          # Hostname for API Manager Analytics Dashboard
+          hostname: "analytics.am.wso2.com"
+          # Annotations for the API Manager Analytics Dashboard service Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
       worker:
         # Container image configurations


### PR DESCRIPTION
## Purpose
> This PR addresses $subject thus fixing the linked issue.

## Goals
> Add input option to set Ingress class and annotations

## Test environment
> Helm version: `3.2.4`
> GKE based Kubernetes Server version: `1.15`+, Git Version: `v1.15.12-gke.2`