### PR TITLE
[3.2.0] Update README documentation with Kubernetes Namespace Creation Argument

### DIFF
--- a/advanced/am-pattern-1/README.md
+++ b/advanced/am-pattern-1/README.md
@@ -62,16 +62,10 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
 
  Helm version 3
 
- - Create the Kubernetes Namespace.
- 
-    ```
-    kubectl create ns <NAMESPACE>
-    ```
-
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> wso2/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE>
+    helm install <RELEASE_NAME> wso2/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE> --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.
@@ -108,16 +102,10 @@ git clone https://github.com/wso2/kubernetes-apim.git
 
  Helm version 3
 
- - Create the Kubernetes Namespace to which you desire to deploy the Kubernetes resources.
- 
-    ```
-    kubectl create ns <NAMESPACE>
-    ```
-
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE> --dependency-update
+    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE> --dependency-update --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.

--- a/advanced/am-pattern-2/README.md
+++ b/advanced/am-pattern-2/README.md
@@ -62,16 +62,10 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
 
  Helm version 3
 
- - Create the Kubernetes Namespace.
- 
-    ```
-    kubectl create ns <NAMESPACE>
-    ```
-
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> wso2/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE>
+    helm install <RELEASE_NAME> wso2/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE> --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.
@@ -108,16 +102,10 @@ git clone https://github.com/wso2/kubernetes-apim.git
 
  Helm version 3
 
- - Create the Kubernetes Namespace to which you desire to deploy the Kubernetes resources.
- 
-    ```
-    kubectl create ns <NAMESPACE>
-    ```
-
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE> --dependency-update
+    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE> --dependency-update --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.

--- a/advanced/am-pattern-3/README.md
+++ b/advanced/am-pattern-3/README.md
@@ -62,16 +62,10 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
 
  Helm version 3
 
- - Create the Kubernetes Namespace.
- 
-    ```
-    kubectl create ns <NAMESPACE>
-    ```
-
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> wso2/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE>
+    helm install <RELEASE_NAME> wso2/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE> --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.
@@ -108,16 +102,10 @@ git clone https://github.com/wso2/kubernetes-apim.git
 
  Helm version 3
 
- - Create the Kubernetes Namespace to which you desire to deploy the Kubernetes resources.
- 
-    ```
-    kubectl create ns <NAMESPACE>
-    ```
-
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE> --dependency-update
+    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE> --dependency-update --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.


### PR DESCRIPTION
## Purpose
> Currently, in README instructions for Helm chart installation we request the users to execute a Kubernetes client (i.e. `kubectl`) command to create the desired Kubernetes Namespace, if not already created.
>
> The need to create a Kubernetes Namespace (if absent) can be achieved by `helm install` command's `create-namespace` argument.

## Goals
> Update README documentation with Kubernetes Namespace creation argument of Helm client

## Test Environment
> Helm version: `3.2.4`
> AWS EKS based Kubernetes Server version: `1.17`+, Git Version: `v1.17.9-eks-4c6976`
> Kubernetes cluster was created using [eksctl](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html)
> WSO2 product images available at WSO2 organization at DockerHub were used
> [NFS Server Provisioner](https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner) was used as the Kubernetes StorageClass solution for persistence/sharing of runtime artifacts
> NGINX Ingress Controller version `0.34.1` was used [fronted by an AWS Network Load Balancer](https://kubernetes.github.io/ingress-nginx/deploy/#network-load-balancer-nlb)