### PR TITLE
Update ingress api version to networking.k8s.io/v1

### DIFF
--- a/advanced/am-pattern-1/README.md
+++ b/advanced/am-pattern-1/README.md
@@ -33,7 +33,7 @@ For advanced details on the deployment pattern, please refer to the official
   and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/) in order to run the steps provided in the
   following quick start guide.<br><br>
 
-* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup).<br><br>
+* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup) ( v1.22+ ).<br><br>
 
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/).<br><br>
 
@@ -58,7 +58,7 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
  Helm version 2
 
  ```
- helm install --name <RELEASE_NAME> wso2/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE>
+ helm install --name <RELEASE_NAME> wso2/am-pattern-1 --version 3.2.0-4 --namespace <NAMESPACE>
  ```
 
  Helm version 3
@@ -66,7 +66,7 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> wso2/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE> --create-namespace
+    helm install <RELEASE_NAME> wso2/am-pattern-1 --version 3.2.0-4 --namespace <NAMESPACE> --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.
@@ -77,7 +77,7 @@ please provide your WSO2 Subscription credentials via input values (using `--set
 Please see the following example.
 
 ```
- helm install --name <RELEASE_NAME> wso2/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+ helm install --name <RELEASE_NAME> wso2/am-pattern-1 --version 3.2.0-4 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
 
 #### Install Chart From Source
@@ -98,7 +98,7 @@ git clone https://github.com/wso2/kubernetes-apim.git
  Helm version 2
 
  ```
- helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE>
+ helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/am-pattern-1 --version 3.2.0-4 --namespace <NAMESPACE>
  ```
 
  Helm version 3
@@ -106,7 +106,7 @@ git clone https://github.com/wso2/kubernetes-apim.git
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE> --dependency-update --create-namespace
+    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-1 --version 3.2.0-4 --namespace <NAMESPACE> --dependency-update --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.
@@ -117,7 +117,7 @@ please provide your WSO2 Subscription credentials via input values (using `--set
 Please see the following example.
 
 ```
- helm install --name <RELEASE_NAME> <HELM_HOME>/am-pattern-1 --version 3.2.0-1 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+ helm install --name <RELEASE_NAME> <HELM_HOME>/am-pattern-1 --version 3.2.0-4 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
 
 ### 2. Obtain the external IP

--- a/advanced/am-pattern-1/README.md
+++ b/advanced/am-pattern-1/README.md
@@ -33,7 +33,7 @@ For advanced details on the deployment pattern, please refer to the official
   and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/) in order to run the steps provided in the
   following quick start guide.<br><br>
 
-* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup) ( v1.22+ ).<br><br>
+* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup) ( v1.19+ ).<br><br>
 
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/).<br><br>
 

--- a/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am-analytics/dashboard/wso2am-pattern-1-am-analytics-dashboard-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-ingress
@@ -30,6 +30,9 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-service
-              servicePort: 9643
+              service:
+                name: {{ template "am-pattern-1.resource.prefix" . }}-am-analytics-dashboard-service
+                port: 
+                  number: 9643

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-gateway-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-gateway-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-1.resource.prefix" . }}-am-gateway-ingress
@@ -30,6 +30,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ template "am-pattern-1.resource.prefix" . }}-am-service
-          servicePort: 8243
+          service:
+            name: {{ template "am-pattern-1.resource.prefix" . }}-am-service
+            port: 
+              number: 8243

--- a/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-ingress.yaml
+++ b/advanced/am-pattern-1/templates/am/wso2am-pattern-1-am-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-1.resource.prefix" . }}-am-ingress
@@ -30,6 +30,9 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ template "am-pattern-1.resource.prefix" . }}-am-service
-              servicePort: 9443
+              service:
+                name: {{ template "am-pattern-1.resource.prefix" . }}-am-service
+                port: 
+                  number: 9443

--- a/advanced/am-pattern-2/README.md
+++ b/advanced/am-pattern-2/README.md
@@ -33,7 +33,7 @@ For advanced details on the deployment pattern, please refer to the official
   and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/) in order to run the steps provided in the
   following quick start guide.<br><br>
 
-* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup) ( v1.22+ ).<br><br>
+* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup) ( v1.19+ ).<br><br>
 
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/).<br><br>
 

--- a/advanced/am-pattern-2/README.md
+++ b/advanced/am-pattern-2/README.md
@@ -33,7 +33,7 @@ For advanced details on the deployment pattern, please refer to the official
   and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/) in order to run the steps provided in the
   following quick start guide.<br><br>
 
-* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup).<br><br>
+* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup) ( v1.22+ ).<br><br>
 
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/).<br><br>
 
@@ -58,7 +58,7 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
  Helm version 2
 
  ```
- helm install --name <RELEASE_NAME> wso2/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE>
+ helm install --name <RELEASE_NAME> wso2/am-pattern-2 --version 3.2.0-4 --namespace <NAMESPACE>
  ```
 
  Helm version 3
@@ -66,7 +66,7 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> wso2/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE> --create-namespace
+    helm install <RELEASE_NAME> wso2/am-pattern-2 --version 3.2.0-4 --namespace <NAMESPACE> --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.
@@ -77,7 +77,7 @@ please provide your WSO2 Subscription credentials via input values (using `--set
 Please see the following example.
 
 ```
- helm install --name <RELEASE_NAME> wso2/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+ helm install --name <RELEASE_NAME> wso2/am-pattern-2 --version 3.2.0-4 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
 
 #### Install Chart From Source
@@ -98,7 +98,7 @@ git clone https://github.com/wso2/kubernetes-apim.git
  Helm version 2
 
  ```
- helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE>
+ helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/am-pattern-2 --version 3.2.0-4 --namespace <NAMESPACE>
  ```
 
  Helm version 3
@@ -106,7 +106,7 @@ git clone https://github.com/wso2/kubernetes-apim.git
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE> --dependency-update --create-namespace
+    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-2 --version 3.2.0-4 --namespace <NAMESPACE> --dependency-update --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.
@@ -117,7 +117,7 @@ please provide your WSO2 Subscription credentials via input values (using `--set
 Please see the following example.
 
 ```
- helm install --name <RELEASE_NAME> <HELM_HOME>/am-pattern-2 --version 3.2.0-1 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+ helm install --name <RELEASE_NAME> <HELM_HOME>/am-pattern-2 --version 3.2.0-4 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
 
 ### 2. Obtain the external IP

--- a/advanced/am-pattern-2/templates/am-analytics/dashboard/wso2am-pattern-2-am-analytics-dashboard-ingress.yaml
+++ b/advanced/am-pattern-2/templates/am-analytics/dashboard/wso2am-pattern-2-am-analytics-dashboard-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-2.resource.prefix" . }}-am-analytics-dashboard-ingress
@@ -30,6 +30,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ template "am-pattern-2.resource.prefix" . }}-am-analytics-dashboard-service
-          servicePort: 9643
+          service:
+            name: {{ template "am-pattern-2.resource.prefix" . }}-am-analytics-dashboard-service
+            port: 
+              number: 9643

--- a/advanced/am-pattern-2/templates/am/gateway/wso2am-pattern-2-am-gateway-ingress.yaml
+++ b/advanced/am-pattern-2/templates/am/gateway/wso2am-pattern-2-am-gateway-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-2.resource.prefix" . }}-am-gateway-ingress
@@ -30,6 +30,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ template "am-pattern-2.resource.prefix" . }}-am-gateway-service
-          servicePort: 8243
+          service:
+            name: {{ template "am-pattern-2.resource.prefix" . }}-am-gateway-service
+            port: 
+              number: 8243

--- a/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-ingress.yaml
+++ b/advanced/am-pattern-2/templates/am/pub-devportal-tm/wso2am-pattern-2-am-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-2.resource.prefix" . }}-am-ingress
@@ -30,6 +30,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ template "am-pattern-2.resource.prefix" . }}-am-service
-          servicePort: 9443
+          service:
+            name: {{ template "am-pattern-2.resource.prefix" . }}-am-service
+            port: 
+              number: 9443

--- a/advanced/am-pattern-3/README.md
+++ b/advanced/am-pattern-3/README.md
@@ -33,7 +33,7 @@ For advanced details on the deployment pattern, please refer to the official
   and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/) in order to run the steps provided in the
   following quick start guide.<br><br>
 
-* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup) ( v1.22+ ).<br><br>
+* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup) ( v1.19+ ).<br><br>
 
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/).<br><br>
 

--- a/advanced/am-pattern-3/README.md
+++ b/advanced/am-pattern-3/README.md
@@ -33,7 +33,7 @@ For advanced details on the deployment pattern, please refer to the official
   and [Kubernetes client](https://kubernetes.io/docs/tasks/tools/install-kubectl/) in order to run the steps provided in the
   following quick start guide.<br><br>
 
-* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup).<br><br>
+* An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup) ( v1.22+ ).<br><br>
 
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/).<br><br>
 
@@ -58,7 +58,7 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
  Helm version 2
 
  ```
- helm install --name <RELEASE_NAME> wso2/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE>
+ helm install --name <RELEASE_NAME> wso2/am-pattern-3 --version 3.2.0-4 --namespace <NAMESPACE>
  ```
 
  Helm version 3
@@ -66,7 +66,7 @@ You can install the relevant Helm chart either from [WSO2 Helm Chart Repository]
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> wso2/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE> --create-namespace
+    helm install <RELEASE_NAME> wso2/am-pattern-3 --version 3.2.0-4 --namespace <NAMESPACE> --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.
@@ -77,7 +77,7 @@ please provide your WSO2 Subscription credentials via input values (using `--set
 Please see the following example.
 
 ```
- helm install --name <RELEASE_NAME> wso2/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+ helm install --name <RELEASE_NAME> wso2/am-pattern-3 --version 3.2.0-4 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
 
 #### Install Chart From Source
@@ -98,7 +98,7 @@ git clone https://github.com/wso2/kubernetes-apim.git
  Helm version 2
 
  ```
- helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE>
+ helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/am-pattern-3 --version 3.2.0-4 --namespace <NAMESPACE>
  ```
 
  Helm version 3
@@ -106,7 +106,7 @@ git clone https://github.com/wso2/kubernetes-apim.git
  - Deploy the Kubernetes resources using the Helm Chart
  
     ```
-    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE> --dependency-update --create-namespace
+    helm install <RELEASE_NAME> <HELM_HOME>/am-pattern-3 --version 3.2.0-4 --namespace <NAMESPACE> --dependency-update --create-namespace
     ```
 
 The above steps will deploy the deployment pattern using WSO2 product Docker images available at DockerHub.
@@ -117,7 +117,7 @@ please provide your WSO2 Subscription credentials via input values (using `--set
 Please see the following example.
 
 ```
- helm install --name <RELEASE_NAME> <HELM_HOME>/am-pattern-3 --version 3.2.0-1 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+ helm install --name <RELEASE_NAME> <HELM_HOME>/am-pattern-3 --version 3.2.0-4 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
 
 ### 2. Obtain the external IP

--- a/advanced/am-pattern-3/templates/am-analytics/dashboard/wso2am-pattern-3-am-analytics-dashboard-ingress.yaml
+++ b/advanced/am-pattern-3/templates/am-analytics/dashboard/wso2am-pattern-3-am-analytics-dashboard-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-3.resource.prefix" . }}-am-analytics-dashboard-ingress
@@ -30,6 +30,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ template "am-pattern-3.resource.prefix" . }}-am-analytics-dashboard-service
-          servicePort: 9643
+          service:
+            name: {{ template "am-pattern-3.resource.prefix" . }}-am-analytics-dashboard-service
+            port:
+              number: 9643

--- a/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-ingress.yaml
+++ b/advanced/am-pattern-3/templates/am/devportal/wso2am-pattern-3-am-devportal-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-ingress
@@ -26,10 +26,13 @@ spec:
     - hosts:
         - {{ .Values.wso2.deployment.am.devportal.ingress.hostname }}
   rules:
-    - host: {{ .Values.wso2.deployment.am.devportal.ingress.hostname }}
-      http:
-        paths:
-        - path: /
-          backend:
-            serviceName: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-service
-            servicePort: 9443
+  - host: {{ .Values.wso2.deployment.am.devportal.ingress.hostname }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "am-pattern-3.resource.prefix" . }}-am-devportal-service
+            port:
+              number: 9443

--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-ingress.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-3.resource.prefix" . }}-am-gateway-ingress
@@ -30,6 +30,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: {{ template "am-pattern-3.resource.prefix" . }}-am-gateway-service
-          servicePort: 8243
+          service:
+            name: {{ template "am-pattern-3.resource.prefix" . }}-am-gateway-service
+            port: 
+              number: 8243

--- a/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-ingress.yaml
+++ b/advanced/am-pattern-3/templates/am/publisher/wso2am-pattern-3-am-publisher-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-ingress
@@ -23,13 +23,16 @@ metadata:
 {{- end }}
 spec:
   tls:
-    - hosts:
-        - {{ .Values.wso2.deployment.am.publisher.ingress.hostname }}
+  - hosts:
+      - {{ .Values.wso2.deployment.am.publisher.ingress.hostname }}
   rules:
-    - host: {{ .Values.wso2.deployment.am.publisher.ingress.hostname }}
-      http:
-        paths:
-        - path: /
-          backend:
-            serviceName: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-service
-            servicePort: 9443
+  - host: {{ .Values.wso2.deployment.am.publisher.ingress.hostname }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "am-pattern-3.resource.prefix" . }}-am-publisher-service
+            port:
+              number: 9443


### PR DESCRIPTION
## Purpose
Update ingress API version to networking.k8s.io/v1 from extensions/v1beta1 which is not supported in Kubernetes 1.22+  
