### PR TITLE
Changed JDBC driver jar mount path.

### DIFF
--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
@@ -116,7 +116,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/dropins
+              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
@@ -116,7 +116,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
+              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
@@ -116,7 +116,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/dropins
+              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
@@ -116,7 +116,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
+              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -122,7 +122,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/dropins
+              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -122,7 +122,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
+              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -122,7 +122,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/dropins
+              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -122,7 +122,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
+              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
@@ -122,7 +122,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/dropins
+              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
@@ -122,7 +122,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
+              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-4/templates/am/control-plane/instance-2/wso2am-pattern-4-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/control-plane/instance-2/wso2am-pattern-4-am-control-plane-deployment.yaml
@@ -122,7 +122,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/dropins
+              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/advanced/am-pattern-4/templates/am/control-plane/instance-2/wso2am-pattern-4-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/control-plane/instance-2/wso2am-pattern-4-am-control-plane-deployment.yaml
@@ -122,7 +122,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
+              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/simple/am-single/templates/am/instance/wso2am-deployment.yaml
+++ b/simple/am-single/templates/am/instance/wso2am-deployment.yaml
@@ -116,7 +116,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/dropins
+              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}

--- a/simple/am-single/templates/am/instance/wso2am-deployment.yaml
+++ b/simple/am-single/templates/am/instance/wso2am-deployment.yaml
@@ -116,7 +116,7 @@ spec:
             {{ end }}
             {{ if .Values.wso2.deployment.dependencies.mysql }}
             - name: mysql-connector-jar
-              mountPath: /home/wso2carbon/wso2-artifact-volume/lib
+              mountPath: /home/wso2carbon/wso2-artifact-volume/repository/components/lib
             {{ end }}
       serviceAccountName: {{ .Values.kubernetes.serviceAccount }}
       {{- if .Values.wso2.deployment.am.imagePullSecrets }}


### PR DESCRIPTION
## Purpose
> When starting the application on kubernetes cluster, the jdbc driver should be placed inside lib folder. 

## Approach
> Changed the mount volume sub path to 'repository/components/lib'. 