### PR TITLE
Allow specification of runtime user

### DIFF
--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
@@ -79,7 +79,8 @@ spec:
               memory: {{ .Values.wso2.deployment.am.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.am.resources.limits.cpu }}
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 8280
               protocol: "TCP"

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
@@ -79,7 +79,8 @@ spec:
               memory: {{ .Values.wso2.deployment.am.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.am.resources.limits.cpu }}
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 8280
               protocol: "TCP"

--- a/advanced/am-pattern-1/templates/mi/instance-1/wso2am-pattern-1-mi-deployment.yaml
+++ b/advanced/am-pattern-1/templates/mi/instance-1/wso2am-pattern-1-mi-deployment.yaml
@@ -69,7 +69,8 @@ spec:
               cpu: {{ .Values.wso2.deployment.mi.resources.limits.cpu }}
           imagePullPolicy: Always
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 8290
               protocol: TCP

--- a/advanced/am-pattern-1/values.yaml
+++ b/advanced/am-pattern-1/values.yaml
@@ -190,6 +190,9 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-1-svc-account"
+  security:
+    runtimeUser: 802
+    runtimeGroup: 802
 
 # Override sub chart parameters
 mysql-am:

--- a/advanced/am-pattern-2/templates/mi/instance-2/wso2am-pattern-2-mi-deployment.yaml
+++ b/advanced/am-pattern-2/templates/mi/instance-2/wso2am-pattern-2-mi-deployment.yaml
@@ -69,7 +69,8 @@ spec:
               cpu: {{ .Values.wso2.deployment.mi.resources.limits.cpu }}
           imagePullPolicy: Always
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 8290
               protocol: TCP

--- a/advanced/am-pattern-2/values.yaml
+++ b/advanced/am-pattern-2/values.yaml
@@ -79,6 +79,9 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: &service_account "wso2am-pattern-2-svc-account"
+  security:
+    runtimeUser: 802
+    runtimeGroup: 802
 
 am-pattern-1:
   wso2:

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -87,7 +87,8 @@ spec:
               memory: {{ .Values.wso2.deployment.am.cp.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.am.cp.resources.limits.cpu }}
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 9763
               protocol: "TCP"

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -87,7 +87,8 @@ spec:
               memory: {{ .Values.wso2.deployment.am.cp.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.am.cp.resources.limits.cpu }}
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 9763
               protocol: "TCP"

--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
@@ -84,7 +84,8 @@ spec:
             memory: {{ .Values.wso2.deployment.am.resources.limits.memory }}
             cpu: {{ .Values.wso2.deployment.am.resources.limits.cpu }}
         securityContext:
-          runAsUser: 802
+          runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+          runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
         ports:
         - containerPort: 8280
           protocol: TCP

--- a/advanced/am-pattern-3/templates/mi/instance-1/wso2am-pattern-3-mi-deployment.yaml
+++ b/advanced/am-pattern-3/templates/mi/instance-1/wso2am-pattern-3-mi-deployment.yaml
@@ -80,7 +80,8 @@ spec:
               cpu: {{ .Values.wso2.deployment.mi.resources.limits.cpu }}
           imagePullPolicy: Always
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 8290
               protocol: TCP

--- a/advanced/am-pattern-3/values.yaml
+++ b/advanced/am-pattern-3/values.yaml
@@ -280,6 +280,9 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-3-svc-account"
+  security:
+    runtimeUser: 802
+    runtimeGroup: 802
 
 # Override sub chart parameters
 mysql-am:

--- a/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
@@ -87,7 +87,8 @@ spec:
               memory: {{ .Values.wso2.deployment.am.cp.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.am.cp.resources.limits.cpu }}
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 9763
               protocol: "TCP"

--- a/advanced/am-pattern-4/templates/am/control-plane/instance-2/wso2am-pattern-4-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/control-plane/instance-2/wso2am-pattern-4-am-control-plane-deployment.yaml
@@ -87,7 +87,8 @@ spec:
               memory: {{ .Values.wso2.deployment.am.cp.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.am.cp.resources.limits.cpu }}
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 9763
               protocol: "TCP"

--- a/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-deployment.yaml
@@ -87,7 +87,8 @@ spec:
             memory: {{ .Values.wso2.deployment.am.resources.limits.memory }}
             cpu: {{ .Values.wso2.deployment.am.resources.limits.cpu }}
         securityContext:
-          runAsUser: 802
+          runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+          runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
         ports:
         - containerPort: 8280
           protocol: TCP

--- a/advanced/am-pattern-4/templates/am/traffic-manager/instance-1/wso2am-pattern-4-am-trafficmanager-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/traffic-manager/instance-1/wso2am-pattern-4-am-trafficmanager-deployment.yaml
@@ -65,7 +65,8 @@ spec:
               memory: {{ .Values.wso2.deployment.am.trafficmanager.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.am.trafficmanager.resources.limits.cpu }}
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 9763
               protocol: "TCP"

--- a/advanced/am-pattern-4/templates/am/traffic-manager/instance-2/wso2am-pattern-4-am-trafficmanager-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/traffic-manager/instance-2/wso2am-pattern-4-am-trafficmanager-deployment.yaml
@@ -65,7 +65,8 @@ spec:
               memory: {{ .Values.wso2.deployment.am.trafficmanager.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.am.trafficmanager.resources.limits.cpu }}
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 9763
               protocol: "TCP"

--- a/advanced/am-pattern-4/templates/mi/wso2am-pattern-4-mi-deployment.yaml
+++ b/advanced/am-pattern-4/templates/mi/wso2am-pattern-4-mi-deployment.yaml
@@ -80,7 +80,8 @@ spec:
               cpu: {{ .Values.wso2.deployment.mi.resources.limits.cpu }}
           imagePullPolicy: Always
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 8290
               protocol: TCP

--- a/advanced/am-pattern-4/values.yaml
+++ b/advanced/am-pattern-4/values.yaml
@@ -323,6 +323,9 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-4-svc-account"
+  security:
+    runtimeUser: 802
+    runtimeGroup: 802
 
 # Override sub chart parameters
 mysql-am:

--- a/simple/am-single/templates/am/instance/wso2am-deployment.yaml
+++ b/simple/am-single/templates/am/instance/wso2am-deployment.yaml
@@ -79,7 +79,8 @@ spec:
               memory: {{ .Values.wso2.deployment.am.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.am.resources.limits.cpu }}
           securityContext:
-            runAsUser: 802
+            runAsUser: {{ .Values.kubernetes.security.runtimeUser }}
+            runAsGroup: {{ .Values.kubernetes.security.runtimeGroup }}
           ports:
             - containerPort: 8280
               protocol: "TCP"

--- a/simple/am-single/values.yaml
+++ b/simple/am-single/values.yaml
@@ -136,6 +136,9 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2am-single-node-svc-account"
+  security:
+    runtimeUser: 802
+    runtimeGroup: 802
 
 # Override sub chart parameters
 mysql-am:


### PR DESCRIPTION

## Purpose
> Allow specification of `runAsUser`and `runAsGroup`. This is needy as some cluster (like openshift) may have security constraints that only accepts some range (on our openshift instance for instance  it `must be in the ranges 1002150000, 1002159999`)



## Goals
> Add some parameters un `values.yml` files with default value to `802` (the previous static value) and reference it in deployment template files.

## Approach
> Add two parameters in `values.yml`. These two are `kubernetes.security.runtimeUser` and `kubernetes.security.runtimeGroup`. I willingly put these values under `kubernetes`as to my mind it is global to the cluster and has nothing to do with a specific business component (`am`, `mi`, `gateway`...)

## User stories
> None

## Release note
> Add two parameters: `kubernetes.security.runtimeUser` to specify the `securityContext.runAsUser` and `kubernetes.security.runtimeGroup`to specify the `securityContext.runAsGroup`

## Documentation
>  “N/A”

## Certification
> “N/A” pure kubernetes runtime issue

## Marketing
>  “N/A”

## Automation tests
 “N/A”

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
 “N/A”

## Related PRs
 “N/A”

## Migrations (if applicable)
 “N/A”

## Test environment
 “N/A”
 
## Learning
 “N/A”