### PR TITLE
[APIM 4.0.0] Fix OutboundAuth Header Config

### DIFF
--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-conf.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-conf.yaml
@@ -124,7 +124,7 @@ data:
     expiry_time = 900
 
     [apim.oauth_config]
-    remove_outbound_auth_header = true
+    enable_outbound_auth_header = false
     auth_header = "Authorization"
 
     [apim.cors]

--- a/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-conf.yaml
+++ b/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-conf.yaml
@@ -152,7 +152,7 @@ data:
     expiry_time = 900
 
     [apim.oauth_config]
-    remove_outbound_auth_header = true
+    enable_outbound_auth_header = false
     auth_header = "Authorization"
 
     [apim.cors]


### PR DESCRIPTION
Related to https://github.com/wso2-enterprise/wso2-apim-internal/issues/16132

This pull request updates the OAuth configuration in the gateway configuration files for both pattern 3 and pattern 4. The main change is replacing the `remove_outbound_auth_header` property with `enable_outbound_auth_header`, and setting it to `false` in both files.

