### PR TITLE
Fix readiness probe endpoint for AM deployments (Fixes #614)

### DIFF
--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
@@ -62,8 +62,9 @@ spec:
             periodSeconds: {{ .Values.wso2.deployment.am.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /services/Version
-              port: 9763
+              path: /api/am/gateway/v2/server-startup-healthcheck
+              port: 9443
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.wso2.deployment.am.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.am.readinessProbe.periodSeconds }}
           lifecycle:

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
@@ -62,8 +62,9 @@ spec:
             periodSeconds: {{ .Values.wso2.deployment.am.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /services/Version
-              port: 9763
+              path: /api/am/gateway/v2/server-startup-healthcheck
+              port: 9443
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.wso2.deployment.am.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.am.readinessProbe.periodSeconds }}
           lifecycle:

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -70,8 +70,9 @@ spec:
             periodSeconds: {{ .Values.wso2.deployment.am.cp.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /services/Version
-              port: 9763
+              path: /api/am/gateway/v2/server-startup-healthcheck
+              port: 9443
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.wso2.deployment.am.cp.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.am.cp.readinessProbe.periodSeconds }}
           lifecycle:

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -70,8 +70,9 @@ spec:
             periodSeconds: {{ .Values.wso2.deployment.am.cp.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /services/Version
-              port: 9763
+              path: /api/am/gateway/v2/server-startup-healthcheck
+              port: 9443
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.wso2.deployment.am.cp.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.am.cp.readinessProbe.periodSeconds }}
           lifecycle:

--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
@@ -69,8 +69,9 @@ spec:
           periodSeconds: {{ .Values.wso2.deployment.am.livenessProbe.periodSeconds }}
         readinessProbe:
           httpGet:
-              path: /services/Version
-              port: 9763
+              path: /api/am/gateway/v2/server-startup-healthcheck
+              port: 9443
+              scheme: HTTPS
           initialDelaySeconds: {{ .Values.wso2.deployment.am.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.wso2.deployment.am.readinessProbe.periodSeconds }}
         lifecycle:

--- a/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
@@ -70,8 +70,9 @@ spec:
             periodSeconds: {{ .Values.wso2.deployment.am.cp.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /services/Version
-              port: 9763
+              path: /api/am/gateway/v2/server-startup-healthcheck
+              port: 9443
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.wso2.deployment.am.cp.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.am.cp.readinessProbe.periodSeconds }}
           lifecycle:

--- a/simple/am-single/templates/am/instance/wso2am-deployment.yaml
+++ b/simple/am-single/templates/am/instance/wso2am-deployment.yaml
@@ -62,8 +62,9 @@ spec:
             periodSeconds: {{ .Values.wso2.deployment.am.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
-              path: /services/Version
-              port: 9763
+              path: /api/am/gateway/v2/server-startup-healthcheck
+              port: 9443
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.wso2.deployment.am.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.am.readinessProbe.periodSeconds }}
           lifecycle:


### PR DESCRIPTION
## Purpose
Fixes #614

The readiness probe in all-in-one setup and gateway deployments was using an outdated endpoint (`/services/Version` on HTTP port 9763). This PR updates the readiness probe to use the proper HTTPS health check endpoint as specified in the issue.

## Changes
Updated readiness probe configuration in all AM deployment templates from:
```yaml
readinessProbe:
  httpGet:
    path: /services/Version
    port: 9763
```
to:
```yaml
readinessProbe:
  httpGet:
    path: /api/am/gateway/v2/server-startup-healthcheck
    port: 9443
    scheme: HTTPS
```

## Affected Files
- `simple/am-single` - AM single node deployment
- - `advanced/am-pattern-1` - instance-1, instance-2
- - `advanced/am-pattern-3` - control-plane instance-1, instance-2, gateway
- - `advanced/am-pattern-4` - control-plane instance-1, instance-2, gateway, traffic-manager instance-1, instance-2
## Testing
The health check endpoint `/api/am/gateway/v2/server-startup-healthcheck` is the correct WSO2 API Manager health check endpoint for Kubernetes readiness probes, using HTTPS on port 9443.
