### PR TITLE
Add ability to control deployment topology using affinity and tolerations

### DIFF
--- a/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-1/wso2am-pattern-1-am-deployment.yaml
@@ -34,6 +34,18 @@ spec:
         node: {{ template "am-pattern-1.resource.prefix" . }}-am-1
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: busybox:1.32

--- a/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
+++ b/advanced/am-pattern-1/templates/am/instance-2/wso2am-pattern-1-am-deployment.yaml
@@ -34,6 +34,18 @@ spec:
         node: {{ template "am-pattern-1.resource.prefix" . }}-am-2
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: busybox:1.32

--- a/advanced/am-pattern-1/templates/mi/instance-1/wso2am-pattern-1-mi-deployment.yaml
+++ b/advanced/am-pattern-1/templates/mi/instance-1/wso2am-pattern-1-mi-deployment.yaml
@@ -40,6 +40,18 @@ spec:
         node: {{ template "am-pattern-1.resource.prefix" . }}-mi-1
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.mi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.mi.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.mi.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-am
           image: busybox:1.32

--- a/advanced/am-pattern-1/values.yaml
+++ b/advanced/am-pattern-1/values.yaml
@@ -63,6 +63,9 @@ wso2:
       # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: Always
 
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
       # Indicates whether the container is running
       livenessProbe:
         # Number of seconds after the container has started before liveness probes are initiated

--- a/advanced/am-pattern-2/templates/mi/instance-2/wso2am-pattern-2-mi-deployment.yaml
+++ b/advanced/am-pattern-2/templates/mi/instance-2/wso2am-pattern-2-mi-deployment.yaml
@@ -40,6 +40,18 @@ spec:
         node: {{ template "am-pattern-2.resource.prefix" . }}-mi-2
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.mi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.mi.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.mi.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-am
           image: busybox:1.32

--- a/advanced/am-pattern-2/values.yaml
+++ b/advanced/am-pattern-2/values.yaml
@@ -138,6 +138,9 @@ am-pattern-1:
         # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
         imagePullPolicy: Always
 
+        nodeSelector: {}
+        affinity: {}
+        tolerations: []
         # Indicates whether the container is running
         livenessProbe:
           # Number of seconds after the container has started before liveness probes are initiated

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-1/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -34,6 +34,18 @@ spec:
         node: {{ template "am-pattern-3.resource.prefix" . }}-am-cp-1
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.cp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.cp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.cp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: busybox:1.32

--- a/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/control-plane/instance-2/wso2am-pattern-3-am-control-plane-deployment.yaml
@@ -34,6 +34,18 @@ spec:
         node: {{ template "am-pattern-3.resource.prefix" . }}-am-cp-2
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.cp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.cp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.cp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: busybox:1.32

--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
@@ -35,6 +35,18 @@ spec:
         deployment: {{ template "am-pattern-3.resource.prefix" . }}-am-gateway
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-cp
           image: busybox:1.32

--- a/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
+++ b/advanced/am-pattern-3/templates/am/gateway/wso2am-pattern-3-am-gateway-deployment.yaml
@@ -35,15 +35,15 @@ spec:
         deployment: {{ template "am-pattern-3.resource.prefix" . }}-am-gateway
         product: apim
     spec:
-      {{- with .Values.wso2.deployment.am.nodeSelector }}
+      {{- with .Values.wso2.deployment.am.gateway.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.wso2.deployment.am.affinity }}
+      {{- with .Values.wso2.deployment.am.gateway.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.wso2.deployment.am.tolerations }}
+      {{- with .Values.wso2.deployment.am.gateway.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/advanced/am-pattern-3/templates/mi/instance-1/wso2am-pattern-3-mi-deployment.yaml
+++ b/advanced/am-pattern-3/templates/mi/instance-1/wso2am-pattern-3-mi-deployment.yaml
@@ -40,6 +40,18 @@ spec:
         node: {{ template "am-pattern-3.resource.prefix" . }}-mi-1
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.mi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.mi.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.mi.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-cp
           image: busybox:1.32

--- a/advanced/am-pattern-3/values.yaml
+++ b/advanced/am-pattern-3/values.yaml
@@ -13,15 +13,10 @@
 # limitations under the License.
 
 wso2:
-  # WSO2 Subscription parameters (https://wso2.com/subscription/)
-  # If provided, these parameters will be used to obtain official WSO2 product Docker images available at WSO2 Private Docker Registry (https://docker.wso2.com/)
-  # for this deployment
   subscription:
     username: ""
     password: ""
 
-  # WSO2 Choreo Analytics Parameters
-  # If provided, these parameters will be used publish analytics data to Choreo Analytics environment (https://apim.docs.wso2.com/en/latest/observe/api-manager-analytics/configure-analytics/register-for-analytics/).
   choreoAnalytics:
     enabled: false
     endpoint: ""
@@ -29,143 +24,90 @@ wso2:
 
   deployment:
     dependencies:
-      # The configuration should be set to be 'true' if a MySQL database should be spawned as a pod within the cluster
       cluster_mysql: true
-      # Enable NFS dynamic provisioner for Kubernetes
       nfsServerProvisioner: true
 
-    # Persisted and shared runtime artifacts for API Manager
-    # See official documentation (from https://apim.docs.wso2.com/en/latest/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts/#persistent-runtime-artifacts)
     persistentRuntimeArtifacts:
-      # Kubernetes Storage Class to be used to dynamically provision the relevant Persistent Volumes
-      # Only persistent storage solutions supporting ReadWriteMany access mode are applicable (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
-      # Defaults to Kubernetes Storage Class generated using the NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner)
       storageClass: &storage_class "nfs"
-
-      # Persistent runtime artifacts for Apache Solr-based indexing
       apacheSolrIndexing:
-        # Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled
-        # By default, this is disabled
         enabled: false
-        # Define capacities for persistent runtime artifact directories
         capacity:
-          # For persisting the H2 based local Carbon database file
           carbonDatabase: 50M
-          # For persisting the indexed data
           solrIndexedData: 50M
 
     am:
-      # Container image configurations
-      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
       dockerRegistry: "docker.wso2.com"
       imageName: "wso2am"
       imageTag: "4.2.0.0"
-      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: Always
 
       nodeSelector: {}
       affinity: {}
       tolerations: []
       resources:
-        # These are the resource recommendations for running WSO2 API Management product profiles with profile optimization
-        # Resource configurations defined here are applicable for all API Manager product profiles of this deployment
         requests:
           memory: "1Gi"
           cpu: "1000m"
         limits:
           memory: "2Gi"
           cpu: "2000m"
-        # JVM settings
-        # These are the resource allocation configurations associated with the JVM
-        # Refer to the official documentation for advanced details (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
         jvm:
-          # Resource allocation for the Java Heap
           heap:
             memory:
-              # Initial and minimum Heap size
               xms: "512m"
-              # Maximum Heap size
               xmx: "512m"
 
-      # Kubernetes Probes
-      # Startup probe executed prior to Liveness Probe taking over
       startupProbe:
-        # Number of seconds after the container has started before startup probes are initiated
         initialDelaySeconds: 45
-        # How often (in seconds) to perform the probe
         periodSeconds: 5
-        # Number of attempts
         failureThreshold: 8
-      # Indicates whether the container is running
       livenessProbe:
-        # How often (in seconds) to perform the probe
         periodSeconds: 10
-        # Indicates whether the container is ready to service requests
       readinessProbe:
-        # Number of seconds after the container has started before readiness probes are initiated
         initialDelaySeconds: 50
-        # How often (in seconds) to perform the probe
         periodSeconds: 10
 
-      # API Manager's WebSub specific configurations
       websub:
-        # Configure Ingress
         ingress:
           enabled: true
-          # Name of the IngressClass to use
           className: ""
-          # Hostname for Gateway (WebSub) service
           hostname: "websub.am.wso2.com"
-          # Annotations for the API Manager Gateway (WebSub) service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-      # API Manager's WebSocket specific configurations
       websocket:
-        # Configure Ingress
         ingress:
           enabled: true
-          # Name of the IngressClass to use
           className: ""
-          # Hostname for Gateway (WebSocket) service
           hostname: "websocket.am.wso2.com"
-          # Annotations for the API Manager Gateway (WebSocket) service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
-      # API Manager's Gateway specific configurations
       gateway:
-        # Configure Ingress
         ingress:
           enabled: true
-          # Name of the IngressClass to use
           className: ""
-          # Hostname for Gateway profile
           hostname: "gateway.am.wso2.com"
-          # Annotations for the API Manager Gateway service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
-        # Number of Gateway replicas
         replicas: 2
-
-        # Kubernetes RollingUpdate strategy configurations
         strategy:
           rollingUpdate:
-            # The maximum number of pods that can be scheduled above the desired number of pods
             maxSurge: 2
-            # The maximum number of pods that can be unavailable during the update
             maxUnavailable: 0
 
-        # If the deployment configurations for the Gateway profile of WSO2 API Manager v3.2.0 (<WSO2AM>/repository/conf/deployment.toml),
-        # add the customized configuration file under (wso2 -> deployment -> am -> gateway -> config -> deployment.toml)
+        # Scheduling controls for the Gateway deployment (independent of other AM components)
+        nodeSelector: {}
+        affinity: {}
+        tolerations: []
+
         # config:
         #   deployment.toml: |-
-        #     # deployment configurations for the Gateway profile of WSO2 API Manager v3.2.0 (<WSO2AM>/repository/conf/deployment.toml)
+        #     # deployment configurations for the Gateway profile of WSO2 API Manager v3.2.0
 
-      # API Manager's Control Plane specific configurations
       cp:
         db:
           hostname: wso2am-mysql-db-service
@@ -181,34 +123,20 @@ wso2:
             username: wso2carbon
             password: wso2carbon
             url: jdbc:mysql://wso2am-mysql-db-service:3306/WSO2AM_SHARED_DB?useSSL=false&amp;autoReconnect=true&amp;requireSSL=false&amp;verifyServerCertificate=false
-        # Kubernetes Probes
-        # Startup probe executed prior to Liveness Probe taking over
         startupProbe:
-          # Number of seconds after the container has started before startup probes are initiated
           initialDelaySeconds: 60
-          # How often (in seconds) to perform the probe
           periodSeconds: 5
-          # Number of attempts
           failureThreshold: 8
-        # Indicates whether the container is running
         livenessProbe:
-          # How often (in seconds) to perform the probe
           periodSeconds: 10
-          # Indicates whether the container is ready to service requests
         readinessProbe:
-          # Number of seconds after the container has started before readiness probes are initiated
           initialDelaySeconds: 80
-          # How often (in seconds) to perform the probe
           periodSeconds: 10
 
-        # Configure Ingress
         ingress:
           enabled: true
-          # Name of the IngressClass to use
           className: ""
-          # Hostname for Control Plane profile
           hostname: "am.wso2.com"
-          # Annotations for the API Manager Control Plane service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
@@ -217,105 +145,71 @@ wso2:
             nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
 
         resources:
-          # These are the minimum resource recommendations for running WSO2 API Management Control Plane deployment
-          # as per official documentation (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
           requests:
             memory: "2Gi"
             cpu: "2000m"
           limits:
             memory: "3Gi"
             cpu: "3000m"
-          # JVM settings
-          # These are the resource allocation configurations associated with the JVM
-          # Refer to the official documentation for advanced details (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
           jvm:
-            # Resource allocation for the Java Heap
             heap:
               memory:
-                # Initial and minimum Heap size
                 xms: "1024m"
-                # Maximum Heap size
                 xmx: "1024m"
 
         # config:
         #   deployment.toml: |-
-        #     # deployment configurations for the Control Plane profile of WSO2 API Manager v4.0.0 (<WSO2AM>/repository/conf/deployment.toml)
+        #     # deployment configurations for the Control Plane profile of WSO2 API Manager v4.0.0
 
     mi:
-      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
       dockerRegistry: "docker.wso2.com"
       imageName: "wso2mi"
       imageTag: "4.2.0.0"
-      # Number of deployment replicas
       replicas: 2
       strategy:
         rollingUpdate:
-          # The maximum number of pods that can be scheduled above the desired number of pods.
           maxSurge: 1
-          # The maximum number of pods that can be unavailable during the update.
           maxUnavailable: 0
-      # Kubernetes Probes
-      # Startup probe executed prior to Liveness Probe taking over
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
       startupProbe:
-        # Number of seconds after the container has started before startup probes are initiated
         initialDelaySeconds: 10
-        # How often (in seconds) to perform the probe
         periodSeconds: 5
-        # Number of attempts
         failureThreshold: 8
-      # Indicates whether the container is running.
       livenessProbe:
-        # How often (in seconds) to perform the probe.
         periodSeconds: 10
-      # Indicates whether the container is ready to service requests.
       readinessProbe:
-        # Number of seconds after the container has started before readiness probes are initiated.
         initialDelaySeconds: 35
-        # How often (in seconds) to perform the probe.
         periodSeconds: 10
-      # These are the minimum resource recommendations for running WSO2 Micro Integrator
       resources:
         requests:
-          # The minimum amount of memory that should be allocated for a Pod
           memory: "512Mi"
-          # The minimum amount of CPU that should be allocated for a Pod
           cpu: "500m"
         limits:
-          # The maximum amount of memory that should be allocated for a Pod
           memory: "1Gi"
-          # The maximum amount of CPU that should be allocated for a Pod
           cpu: "1000m"
-      # Environment variables for the Micro integrator deployment.
       envs:
       #  ENV_NAME: ENV_VALUE
 
-      # Add the customized deployment configurations for the WSO2 MI v4.2.0 (<WSO2MI>/conf/deployment.toml)
       # config:
       #   deployment.toml: |-
       #     # toml configurations for the WSO2 MI v4.2.0
 
-      # Configure synapse testing.
       synapseTest:
         enabled: false
 
-      # Configure Ingresses
       ingress:
-        # Name of the IngressClass to use
         className: ""
-        # Configure management ingress
         management:
-          # Hostname for the Micro Integrator management endpoint.
           hostname: "management.mi.wso2.com"
-          # Annotations for the Micro Integrator management Ingress.
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
 kubernetes:
-  # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-3-svc-account"
 
-# Override sub chart parameters
 mysql-am:
   mysql:
     persistence:

--- a/advanced/am-pattern-3/values.yaml
+++ b/advanced/am-pattern-3/values.yaml
@@ -63,6 +63,9 @@ wso2:
       # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: Always
 
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
       resources:
         # These are the resource recommendations for running WSO2 API Management product profiles with profile optimization
         # Resource configurations defined here are applicable for all API Manager product profiles of this deployment

--- a/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/control-plane/instance-1/wso2am-pattern-4-am-control-plane-deployment.yaml
@@ -34,6 +34,18 @@ spec:
         node: {{ template "am-pattern-4.resource.prefix" . }}-am-cp-1
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.cp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.cp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.cp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: busybox:1.32

--- a/advanced/am-pattern-4/templates/am/control-plane/instance-2/wso2am-pattern-4-am-control-plane-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/control-plane/instance-2/wso2am-pattern-4-am-control-plane-deployment.yaml
@@ -34,6 +34,18 @@ spec:
         node: {{ template "am-pattern-4.resource.prefix" . }}-am-cp-2
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.cp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.cp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.cp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: busybox:1.32

--- a/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-deployment.yaml
@@ -35,15 +35,15 @@ spec:
         deployment: {{ template "am-pattern-4.resource.prefix" . }}-am-gateway
         product: apim
     spec:
-      {{- with .Values.wso2.deployment.am.nodeSelector }}
+      {{- with .Values.wso2.deployment.am.gateway.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.wso2.deployment.am.affinity }}
+      {{- with .Values.wso2.deployment.am.gateway.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.wso2.deployment.am.tolerations }}
+      {{- with .Values.wso2.deployment.am.gateway.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/gateway/wso2am-pattern-4-am-gateway-deployment.yaml
@@ -35,6 +35,18 @@ spec:
         deployment: {{ template "am-pattern-4.resource.prefix" . }}-am-gateway
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-tm1
           image: busybox:1.32

--- a/advanced/am-pattern-4/templates/am/traffic-manager/instance-1/wso2am-pattern-4-am-trafficmanager-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/traffic-manager/instance-1/wso2am-pattern-4-am-trafficmanager-deployment.yaml
@@ -34,6 +34,18 @@ spec:
         node: {{ template "am-pattern-4.resource.prefix" . }}-am-trafficmanager-1
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.trafficmanager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.trafficmanager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.trafficmanager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-cp
           image: busybox:1.32

--- a/advanced/am-pattern-4/templates/am/traffic-manager/instance-2/wso2am-pattern-4-am-trafficmanager-deployment.yaml
+++ b/advanced/am-pattern-4/templates/am/traffic-manager/instance-2/wso2am-pattern-4-am-trafficmanager-deployment.yaml
@@ -34,6 +34,18 @@ spec:
         node: {{ template "am-pattern-4.resource.prefix" . }}-am-trafficmanager-2
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.trafficmanager.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.trafficmanager.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.trafficmanager.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-cp
           image: busybox:1.32

--- a/advanced/am-pattern-4/templates/mi/wso2am-pattern-4-mi-deployment.yaml
+++ b/advanced/am-pattern-4/templates/mi/wso2am-pattern-4-mi-deployment.yaml
@@ -40,6 +40,18 @@ spec:
         node: {{ template "am-pattern-4.resource.prefix" . }}-mi
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.mi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.mi.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.mi.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-cp
           image: busybox:1.32

--- a/advanced/am-pattern-4/values.yaml
+++ b/advanced/am-pattern-4/values.yaml
@@ -13,15 +13,10 @@
 # limitations under the License.
 
 wso2:
-  # WSO2 Subscription parameters (https://wso2.com/subscription/)
-  # If provided, these parameters will be used to obtain official WSO2 product Docker images available at WSO2 Private Docker Registry (https://docker.wso2.com/)
-  # for this deployment
   subscription:
     username: ""
     password: ""
 
-  # WSO2 Choreo Analytics Parameters
-  # If provided, these parameters will be used publish analytics data to Choreo Analytics environment (https://apim.docs.wso2.com/en/latest/observe/api-manager-analytics/configure-analytics/register-for-analytics/).
   choreoAnalytics:
     enabled: false
     endpoint: ""
@@ -29,185 +24,115 @@ wso2:
 
   deployment:
     dependencies:
-      # The configuration should be set to be 'true' if a MySQL database should be spawned as a pod within the cluster
       cluster_mysql: true
-      # Enable NFS dynamic provisioner for Kubernetes
       nfsServerProvisioner: true
 
-    # Persisted and shared runtime artifacts for API Manager
-    # See official documentation (from https://apim.docs.wso2.com/en/latest/install-and-setup/setup/reference/common-runtime-and-configuration-artifacts/#persistent-runtime-artifacts)
     persistentRuntimeArtifacts:
-      # Kubernetes Storage Class to be used to dynamically provision the relevant Persistent Volumes
-      # Only persistent storage solutions supporting ReadWriteMany access mode are applicable (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
-      # Defaults to Kubernetes Storage Class generated using the NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner)
       storageClass: &storage_class "nfs"
-
-      # Persistent runtime artifacts for Apache Solr-based indexing
       apacheSolrIndexing:
-        # Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled
-        # By default, this is disabled
         enabled: false
-        # Define capacities for persistent runtime artifact directories
         capacity:
-          # For persisting the H2 based local Carbon database file
           carbonDatabase: 50M
-          # For persisting the indexed data
           solrIndexedData: 50M
 
     am:
-      # Container image configurations
-      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
       dockerRegistry: "docker.wso2.com"
       imageName: "wso2am"
       imageTag: "4.2.0.0"
-      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: Always
 
       nodeSelector: {}
       affinity: {}
       tolerations: []
       resources:
-        # These are the resource recommendations for running WSO2 API Management product profiles with profile optimization
-        # Resource configurations defined here are applicable for all API Manager product profiles of this deployment
         requests:
           memory: "1Gi"
           cpu: "1000m"
         limits:
           memory: "2Gi"
           cpu: "2000m"
-        # JVM settings
-        # These are the resource allocation configurations associated with the JVM
-        # Refer to the official documentation for advanced details (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
         jvm:
-          # Resource allocation for the Java Heap
           heap:
             memory:
-              # Initial and minimum Heap size
               xms: "512m"
-              # Maximum Heap size
               xmx: "512m"
 
-      # Kubernetes Probes
-      # Startup probe executed prior to Liveness Probe taking over
       startupProbe:
-        # Number of seconds after the container has started before startup probes are initiated
         initialDelaySeconds: 45
-        # How often (in seconds) to perform the probe
         periodSeconds: 5
-        # Number of attempts
         failureThreshold: 8
-      # Indicates whether the container is running
       livenessProbe:
-        # How often (in seconds) to perform the probe
         periodSeconds: 10
-        # Indicates whether the container is ready to service requests
       readinessProbe:
-        # Number of seconds after the container has started before readiness probes are initiated
         initialDelaySeconds: 50
-        # How often (in seconds) to perform the probe
         periodSeconds: 10
 
-      # API Manager's WebSub specific configurations
       websub:
-        # Configure Ingress
         ingress:
           enabled: true
-          # Name of the IngressClass to use
           className: ""
-          # Hostname for Gateway (WebSub) service
           hostname: "websub.am.wso2.com"
-          # Annotations for the API Manager Gateway (WebSub) service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
-      # API Manager's WebSocket specific configurations
       websocket:
-        # Configure Ingress
         ingress:
           enabled: true
-          # Name of the IngressClass to use
           className: ""
-          # Hostname for Gateway (WebSocket) service
           hostname: "websocket.am.wso2.com"
-          # Annotations for the API Manager Gateway (WebSocket) service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
-      # API Manager's Gateway specific configurations
       gateway:
-        # Configure Ingress
         ingress:
           enabled: true
-          # Name of the IngressClass to use
           className: ""
-          # Hostname for Gateway profile
           hostname: "gateway.am.wso2.com"
-          # Annotations for the API Manager Gateway service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
-        # Number of Gateway replicas
         replicas: 2
-
-        # Kubernetes RollingUpdate strategy configurations
         strategy:
           rollingUpdate:
-            # The maximum number of pods that can be scheduled above the desired number of pods
             maxSurge: 2
-            # The maximum number of pods that can be unavailable during the update
             maxUnavailable: 0
 
-        # If the deployment configurations for the Gateway profile of WSO2 API Manager v4.0.0 (<WSO2AM>/repository/conf/deployment.toml),
-        # add the customized configuration file under (wso2 -> deployment -> am -> gateway -> config -> deployment.toml)
+        # Scheduling controls for the Gateway deployment (independent of other AM components)
+        nodeSelector: {}
+        affinity: {}
+        tolerations: []
+
         # config:
         #   deployment.toml: |-
-        #     # deployment configurations for the Gateway profile of WSO2 API Manager v4.0.0 (<WSO2AM>/repository/conf/deployment.toml)
+        #     # deployment configurations for the Gateway profile of WSO2 API Manager v4.0.0
 
-      # API Manager's Traffic Manager specific configurations
       trafficmanager:
-        # Indicates whether the container is running
         livenessProbe:
-          # Number of seconds after the container has started before liveness probes are initiated
           initialDelaySeconds: 180
-          # How often (in seconds) to perform the probe
           periodSeconds: 10
-        # Indicates whether the container is ready to service requests
         readinessProbe:
-          # Number of seconds after the container has started before readiness probes are initiated
           initialDelaySeconds: 180
-          # How often (in seconds) to perform the probe
           periodSeconds: 10
         resources:
-          # These are the minimum resource recommendations for running WSO2 API Management Control Plane deployment
-          # as per official documentation (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
           requests:
             memory: "2Gi"
             cpu: "2000m"
           limits:
             memory: "3Gi"
             cpu: "3000m"
-          # JVM settings
-          # These are the resource allocation configurations associated with the JVM
-          # Refer to the official documentation for advanced details (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
           jvm:
-            # Resource allocation for the Java Heap
             heap:
               memory:
-                # Initial and minimum Heap size
                 xms: "1024m"
-                # Maximum Heap size
                 xmx: "1024m"
 
-        # If the deployment configurations for the Gateway profile of WSO2 API Manager v4.0.0 (<WSO2AM>/repository/conf/deployment.toml),
-        # add the customized configuration file under (wso2 -> deployment -> am -> gateway -> config -> deployment.toml)
         # config:
         #   deployment.toml: |-
-        #     # deployment configurations for the Gateway profile of WSO2 API Manager v4.0.0 (<WSO2AM>/repository/conf/deployment.toml)
+        #     # deployment configurations for the Gateway profile of WSO2 API Manager v4.0.0
 
-      # API Manager's Control Plane specific configurations
       cp:
         db:
           hostname: wso2am-mysql-db-service
@@ -223,34 +148,20 @@ wso2:
             username: wso2carbon
             password: wso2carbon
             url: jdbc:mysql://wso2am-mysql-db-service:3306/WSO2AM_SHARED_DB?useSSL=false&amp;autoReconnect=true&amp;requireSSL=false&amp;verifyServerCertificate=false
-        # Kubernetes Probes
-        # Startup probe executed prior to Liveness Probe taking over
         startupProbe:
-          # Number of seconds after the container has started before startup probes are initiated
           initialDelaySeconds: 60
-          # How often (in seconds) to perform the probe
           periodSeconds: 5
-          # Number of attempts
           failureThreshold: 8
-        # Indicates whether the container is running
         livenessProbe:
-          # How often (in seconds) to perform the probe
           periodSeconds: 10
-          # Indicates whether the container is ready to service requests
         readinessProbe:
-          # Number of seconds after the container has started before readiness probes are initiated
           initialDelaySeconds: 80
-          # How often (in seconds) to perform the probe
           periodSeconds: 10
 
-        # Configure Ingress
         ingress:
           enabled: true
-          # Name of the IngressClass to use
           className: ""
-          # Hostname for Control Plane profile
           hostname: "am.wso2.com"
-          # Annotations for the API Manager Control Plane service Ingress
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
@@ -259,105 +170,71 @@ wso2:
             nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
 
         resources:
-          # These are the minimum resource recommendations for running WSO2 API Management Control Plane deployment
-          # as per official documentation (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
           requests:
             memory: "2Gi"
             cpu: "2000m"
           limits:
             memory: "3Gi"
             cpu: "3000m"
-          # JVM settings
-          # These are the resource allocation configurations associated with the JVM
-          # Refer to the official documentation for advanced details (https://apim.docs.wso2.com/en/latest/install-and-setup/install/installation-prerequisites/)
           jvm:
-            # Resource allocation for the Java Heap
             heap:
               memory:
-                # Initial and minimum Heap size
                 xms: "1024m"
-                # Maximum Heap size
                 xmx: "1024m"
 
         # config:
         #   deployment.toml: |-
-        #     # deployment configurations for the Control Plane profile of WSO2 API Manager v4.0.0 (<WSO2AM>/repository/conf/deployment.toml)
+        #     # deployment configurations for the Control Plane profile of WSO2 API Manager v4.0.0
 
     mi:
-      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
       dockerRegistry: "docker.wso2.com"
       imageName: "wso2mi"
       imageTag: "4.2.0.0"
-      # Number of MI replicas
       replicas: 2
       strategy:
         rollingUpdate:
-          # The maximum number of pods that can be scheduled above the desired number of pods.
           maxSurge: 1
-          # The maximum number of pods that can be unavailable during the update.
           maxUnavailable: 0
-      # Kubernetes Probes
-      # Startup probe executed prior to Liveness Probe taking over
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
       startupProbe:
-        # Number of seconds after the container has started before startup probes are initiated
         initialDelaySeconds: 10
-        # How often (in seconds) to perform the probe
         periodSeconds: 5
-        # Number of attempts
         failureThreshold: 8
-      # Indicates whether the container is running.
       livenessProbe:
-        # How often (in seconds) to perform the probe.
         periodSeconds: 10
-      # Indicates whether the container is ready to service requests.
       readinessProbe:
-        # Number of seconds after the container has started before readiness probes are initiated.
         initialDelaySeconds: 35
-        # How often (in seconds) to perform the probe.
         periodSeconds: 10
-      # These are the minimum resource recommendations for running WSO2 Micro Integrator
       resources:
         requests:
-          # The minimum amount of memory that should be allocated for a Pod
           memory: "512Mi"
-          # The minimum amount of CPU that should be allocated for a Pod
           cpu: "500m"
         limits:
-          # The maximum amount of memory that should be allocated for a Pod
           memory: "1Gi"
-          # The maximum amount of CPU that should be allocated for a Pod
           cpu: "1000m"
-      # Environment variables for the Micro integrator deployment.
       envs:
       #  ENV_NAME: ENV_VALUE
 
-      # Add the customized deployment configurations for the WSO2 MI v4.2.0 (<WSO2MI>/conf/deployment.toml)
       # config:
       #   deployment.toml: |-
       #     # toml configurations for the WSO2 MI v4.2.0
 
-      # Configure synapse testing.
       synapseTest:
         enabled: false
 
-      # Configure Ingresses
       ingress:
-        # Name of the IngressClass to use
         className: ""
-        # Configure management ingress
         management:
-          # Hostname for the Micro Integrator management endpoint.
           hostname: "management.mi.wso2.com"
-          # Annotations for the Micro Integrator management Ingress.
           annotations:
             kubernetes.io/ingress.class: "nginx"
             nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 
 kubernetes:
-  # Name of Kubernetes service account
   serviceAccount: "wso2am-pattern-4-svc-account"
 
-# Override sub chart parameters
 mysql-am:
   mysql:
     persistence:

--- a/advanced/am-pattern-4/values.yaml
+++ b/advanced/am-pattern-4/values.yaml
@@ -63,6 +63,9 @@ wso2:
       # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: Always
 
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
       resources:
         # These are the resource recommendations for running WSO2 API Management product profiles with profile optimization
         # Resource configurations defined here are applicable for all API Manager product profiles of this deployment

--- a/simple/am-single/templates/am/instance/wso2am-deployment.yaml
+++ b/simple/am-single/templates/am/instance/wso2am-deployment.yaml
@@ -34,6 +34,18 @@ spec:
         node: {{ template "am-single-node.resource.prefix" . }}-am
         product: apim
     spec:
+      {{- with .Values.wso2.deployment.am.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.wso2.deployment.am.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init-db
           image: busybox:1.32

--- a/simple/am-single/values.yaml
+++ b/simple/am-single/values.yaml
@@ -63,6 +63,9 @@ wso2:
       # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: Always
 
+      nodeSelector: {}
+      affinity: {}
+      tolerations: []
       # Indicates whether the container is running
       livenessProbe:
         # Number of seconds after the container has started before liveness probes are initiated


### PR DESCRIPTION
Fixes wso2/kubernetes-apim#610. This PR introduces the ability to control deployment topologies using 
odeSelector, ffinity, and 	olerations parameters across all WSO2 APIM and MI deployment manifests. It enables DevOps teams to dictate where the API Manager components run within their clusters.